### PR TITLE
test(orders): green the lab-order integration test as the order-suite pattern

### DIFF
--- a/server/src/modules/Orders/Laboratory/lab-order.test.ts
+++ b/server/src/modules/Orders/Laboratory/lab-order.test.ts
@@ -3,64 +3,59 @@ import { describe, afterAll, it, expect, beforeAll } from '@jest/globals';
 import server from '../../../core/startup/server';
 
 import request from 'supertest';
-import { OPD } from '../../../core/constants';
 
-import { Staff, PrescribedTest, Visit } from '../../../database/models';
-
-const tests = [
-  {
-    test_id: 1,
-    test_type: 'CASH',
-    price: 200,
-  },
-  {
-    test_id: 2,
-    test_type: 'NHIS',
-    price: 250,
-  },
-  {
-    test_id: 3,
-    test_type: 'CASH',
-    price: 150,
-  },
-];
+import {
+  cleanUpOrderFixtures,
+  createVisitContext,
+  seedLabCatalogue,
+} from '../__fixtures__/order-fixtures';
 
 describe('Lab Order Endpoints /tests/lab', () => {
   let token;
   let visit_id;
+  let tests;
   beforeAll(async () => {
-    const staff = await Staff.create({
-      firstname: 'Fatai',
-      phone: '07035121699',
-      lastname: 'Mahmud',
-      fullname: 'Mahmud Aze',
-      username: 'wale',
-      gender: 'Male',
-      address: 'Kubwa',
-      photo: 'IMG_20202022.jpg',
-      password: '123456',
-      email: 'ajao@gmail.com',
-      department: 'Medical',
-      role: 'Doctor',
-      sub_role: 'GP',
-      date_of_birth: '1994-09-02',
-    });
-    token = await staff.generateAuthToken();
-    const visit = await Visit.create({
-      patient_id: 1,
-      type: OPD,
-      staff_id: staff.id,
-    });
-    visit_id = visit.id;
+    const context = await createVisitContext();
+    token = context.token;
+    visit_id = context.visit_id;
+
+    // The order references sample and test rows by FK, so seed them and build the request body
+    // from the ids that were actually created rather than from magic numbers.
+    const { sampleIds, testIds } = await seedLabCatalogue(context.staff.id);
+    tests = [
+      {
+        test_id: testIds[0],
+        test_type: 'CASH',
+        sample_id: sampleIds[0],
+        price: 200,
+        is_urgent: false,
+        source: 'Consultation',
+      },
+      {
+        test_id: testIds[1],
+        test_type: 'NHIS',
+        sample_id: sampleIds[0],
+        price: 250,
+        is_urgent: true,
+        source: 'Consultation',
+      },
+      {
+        test_id: testIds[2],
+        test_type: 'CASH',
+        sample_id: sampleIds[1],
+        price: 150,
+        is_urgent: false,
+        source: 'Consultation',
+      },
+    ];
   }, 14000);
   afterAll(async () => {
-    await Staff.destroy({ truncate: true, cascade: false });
-    await PrescribedTest.destroy({ truncate: true, cascade: false });
+    await cleanUpOrderFixtures();
   });
 
   it('should order a lab test', async () => {
     const res = await request(server)
-      .post(`/api/orders/lab/create/${visit_id}`)
+      .post(`/api/orders/laboratory/create/${visit_id}`)
       .set('Authorization', `Bearer ${token}`)
       .send({
         tests,

--- a/server/src/modules/Orders/__fixtures__/order-fixtures.ts
+++ b/server/src/modules/Orders/__fixtures__/order-fixtures.ts
@@ -1,4 +1,5 @@
 /* eslint-disable camelcase */
+import { Model, ModelStatic } from 'sequelize';
 import { PrescribedTest, Patient, Sample, Staff, Test, Visit } from '../../../database/models';
 import { VisitCategory } from '../../../database/enums';
 import { OPD } from '../../../core/constants';
@@ -33,7 +34,9 @@ function unique(prefix: string): string {
  * this fixture owns without having to know the full downstream graph. `truncate` is used per
  * table so auto-increment ids reset between suites.
  */
-const FIXTURE_TABLES = [PrescribedTest, Test, Sample, Visit, Patient, Staff] as const;
+// Typed as the shared ModelStatic base: the entries are different model classes, and we only
+// call destroy(), which every model exposes identically.
+const FIXTURE_TABLES: ModelStatic<Model>[] = [PrescribedTest, Test, Sample, Visit, Patient, Staff];
 
 export async function cleanUpOrderFixtures(): Promise<void> {
   const sequelize = Staff.sequelize;

--- a/server/src/modules/Orders/__fixtures__/order-fixtures.ts
+++ b/server/src/modules/Orders/__fixtures__/order-fixtures.ts
@@ -1,0 +1,151 @@
+/* eslint-disable camelcase */
+import { PrescribedTest, Patient, Sample, Staff, Test, Visit } from '../../../database/models';
+import { VisitCategory } from '../../../database/enums';
+import { OPD } from '../../../core/constants';
+
+/**
+ * Shared fixtures for the order-creation integration tests (lab / pharmacy / radiology / service).
+ *
+ * Kept in one place because all four suites need the same valid Staff → Patient → Visit chain, and
+ * the reason these tests broke in the first place was a `Visit` fixture that predated columns the
+ * schema now requires (`category`, `date_visit_start`, `department`, `professional`). A single
+ * source of truth means the next schema change breaks one file, not four.
+ *
+ * These build REAL rows against the test database. Every NOT-NULL column with no default, and
+ * every model-level validator, is satisfied here.
+ */
+
+let uniqueCounter = 0;
+
+/** A monotonic suffix so parallel-safe unique columns (username, phone, email) never collide. */
+function unique(prefix: string): string {
+  uniqueCounter += 1;
+  return `${prefix}_${Date.now()}_${uniqueCounter}`;
+}
+
+/**
+ * Removes everything the order fixtures and the endpoints under test create.
+ *
+ * Ordering the deletes by hand is brittle here: an order endpoint also writes rows this file
+ * never named (encounters, test-prescription groupings, …), and each new endpoint tested would
+ * add another table to chase. Disabling FK checks for the duration of the teardown — a standard
+ * test-DB pattern, safe because the connection is a throwaway test database — deletes the tables
+ * this fixture owns without having to know the full downstream graph. `truncate` is used per
+ * table so auto-increment ids reset between suites.
+ */
+const FIXTURE_TABLES = [PrescribedTest, Test, Sample, Visit, Patient, Staff] as const;
+
+export async function cleanUpOrderFixtures(): Promise<void> {
+  const sequelize = Staff.sequelize;
+  if (!sequelize) {
+    throw new Error('Staff model is not attached to a Sequelize instance.');
+  }
+
+  await sequelize.query('SET FOREIGN_KEY_CHECKS = 0');
+  try {
+    for (const model of FIXTURE_TABLES) {
+      await model.destroy({ where: {}, truncate: true, force: true });
+    }
+  } finally {
+    await sequelize.query('SET FOREIGN_KEY_CHECKS = 1');
+  }
+}
+
+export async function createTestStaff(): Promise<Staff> {
+  return Staff.create({
+    firstname: 'Test',
+    lastname: 'Doctor',
+    middlename: '',
+    phone: unique('080'),
+    username: unique('doctor'),
+    gender: 'Male',
+    address: 'Test Address',
+    photo: 'photo.jpg',
+    password: '123456',
+    email: `${unique('doctor')}@example.com`,
+    department: 'Medical',
+    role: 'Doctor',
+    sub_role: 'GP',
+    date_of_birth: '1990-01-01',
+  } as never);
+}
+
+export async function createTestPatient(): Promise<Patient> {
+  return Patient.create({
+    firstname: 'Test',
+    lastname: 'Patient',
+    gender: 'Male',
+    phone: unique('070'),
+    address: 'Test Patient Address',
+    country: 'Nigeria',
+    state: 'Lagos',
+    lga: 'Ikeja',
+    date_of_birth: '1995-05-05',
+  } as never);
+}
+
+/**
+ * Seeds the minimal lab reference catalogue an order references by FK: sample types and the tests
+ * that belong to them. A freshly-loaded schema is empty, so without this a PrescribedTest insert
+ * fails a foreign-key constraint (`sample_id -> Test_Samples`, `test_id -> Tests`) — which is the
+ * real reason these tests broke against a clean database rather than the populated dev one.
+ *
+ * Returns the seeded test/sample ids so a test asserts against what it seeded, not against magic
+ * numbers.
+ */
+export async function seedLabCatalogue(
+  staffId: number
+): Promise<{ sampleIds: number[]; testIds: number[] }> {
+  const bloodSample = await Sample.create({ name: 'Blood', staff_id: staffId } as never);
+  const urineSample = await Sample.create({ name: 'Urine', staff_id: staffId } as never);
+
+  const test = (name: string, code: string, sample_id: number) =>
+    Test.create({
+      name,
+      code,
+      price: '100.00',
+      sample_id,
+      type: 'Primary',
+      result_unit: 'mg/dL',
+      valid_range: '0-100',
+      staff_id: staffId,
+    } as never);
+
+  const t1 = await test('Full Blood Count', 'FBC', bloodSample.id);
+  const t2 = await test('Malaria Parasite', 'MP', bloodSample.id);
+  const t3 = await test('Urinalysis', 'URIN', urineSample.id);
+
+  return {
+    sampleIds: [bloodSample.id, urineSample.id],
+    testIds: [t1.id, t2.id, t3.id],
+  };
+}
+
+/**
+ * A Staff, a Patient, and an open Outpatient Visit linking them — the precondition every order
+ * endpoint assumes. Returns the ids and an auth token for the requests.
+ */
+export async function createVisitContext(): Promise<{
+  staff: Staff;
+  patient: Patient;
+  visit: Visit;
+  visit_id: number;
+  token: string;
+}> {
+  const staff = await createTestStaff();
+  const patient = await createTestPatient();
+
+  const visit = await Visit.create({
+    patient_id: patient.id,
+    staff_id: staff.id,
+    category: VisitCategory.OPD,
+    date_visit_start: new Date(),
+    department: 'Medical',
+    professional: 'Doctor',
+    type: OPD,
+  } as never);
+
+  const token = await staff.generateAuthToken();
+
+  return { staff, patient, visit, visit_id: visit.id, token };
+}


### PR DESCRIPTION
Stacked on #3 (test DB provisioning). Third in the sequence: #2 made tests parse, #3 gave them a database, this makes one of them actually pass end-to-end — establishing the pattern the other order suites will follow.

## What broke, and why

`lab-order.test.ts` was written against a populated dev database. Against the freshly-provisioned schema it failed at four distinct points, each a real drift between the test and current app behaviour:

| Symptom | Cause | Fix |
|---|---|---|
| `Visit.category cannot be null` | Fixture predated `category`/`date_visit_start`/`department`/`professional` | Shared `order-fixtures.ts` helper with a valid Staff→Patient→Visit chain |
| `404` | Route moved `/orders/lab` → `/orders/laboratory` | Updated path |
| `400` | Body predated validation (`sample_id`, `is_urgent`, `source`) | Updated payload |
| `500` foreign-key fail | Empty reference catalogue — no `Test_Samples`/`Tests` in a clean schema | `seedLabCatalogue` seeds the minimal chain |

## The pattern this establishes

- **`order-fixtures.ts`** — one source of truth for the Staff/Patient/Visit chain every order endpoint needs, so the next schema change breaks one file instead of four.
- **`seedLabCatalogue`** returns the ids it seeds, so the test asserts against what it created rather than magic numbers.
- **Teardown disables FK checks** for its duration rather than hand-ordering deletes — an order endpoint writes rows this fixture never names (encounters, test-prescription groupings), and chasing that graph per endpoint is brittle. Standard test-DB pattern, safe on a throwaway database.

Verified the test passes **twice consecutively without a DB reset**, so teardown genuinely resets state.

## Scope

This greens **lab-order only**, deliberately. `pharmacy-order.test.ts` and `radiology-order.test.ts` turned out to be **empty placeholder files** (never written), and `service-order` has no test at all. Writing those three is done when issue #4's outbox work (A1.2) touches those clinical paths — they reuse this helper. Greening all order paths up front would be a test-authoring project beyond what's needed now.

## The sequence so far

`#2` (tests parse) → `#3` (test DB) → **this** (lab-order green, pattern set). Together they take the EMR's suite from *0 tests running* to a working harness with a real, extensible example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)