### PR TITLE
feat(inbox): reverse Accounting→EMR inbox — issue #4 Phase B2

### DIFF
--- a/server/src/core/command/index.ts
+++ b/server/src/core/command/index.ts
@@ -18,11 +18,12 @@ export const CronTimer = {
   [JobName.CLOSE_ANTENATAL_ACCOUNT]: '0 1 * * *', // every 1am
   [JobName.END_VISIT]: '0 0 * * *', // 12am
   // Frequent: settlement latency matters, and a no-op pass is cheap when the flag is off or the
-  // outbox is empty.
-  [JobName.DRAIN_OUTBOX]: '* * * * *', // every minute
+  // outbox is empty. Overridable via env so an integration harness can drain sub-minute; defaults
+  // to every minute.
+  [JobName.DRAIN_OUTBOX]: process.env.EMR_OUTBOX_DRAIN_CRON || '* * * * *',
   // Frequent for the same reason: a paid patient's gate should open promptly once the instruction
   // arrives, and a no-op pass is cheap when the inbox is empty or the flag is off.
-  [JobName.DRAIN_INBOX]: '* * * * *', // every minute
+  [JobName.DRAIN_INBOX]: process.env.EMR_INBOX_DRAIN_CRON || '* * * * *',
 };
 
 export const ImmediateJob = {};

--- a/server/src/core/command/index.ts
+++ b/server/src/core/command/index.ts
@@ -9,6 +9,7 @@ export enum JobName {
   END_VISIT = 'End visit',
   CLOSE_ANTENATAL_ACCOUNT = 'Close antenatal account',
   DRAIN_OUTBOX = 'Drain EMR-Accounting outbox',
+  DRAIN_INBOX = 'Drain Accounting-EMR inbox',
 }
 
 export const CronTimer = {
@@ -19,6 +20,9 @@ export const CronTimer = {
   // Frequent: settlement latency matters, and a no-op pass is cheap when the flag is off or the
   // outbox is empty.
   [JobName.DRAIN_OUTBOX]: '* * * * *', // every minute
+  // Frequent for the same reason: a paid patient's gate should open promptly once the instruction
+  // arrives, and a no-op pass is cheap when the inbox is empty or the flag is off.
+  [JobName.DRAIN_INBOX]: '* * * * *', // every minute
 };
 
 export const ImmediateJob = {};

--- a/server/src/core/command/jobs/cron/drainInbox.job.ts
+++ b/server/src/core/command/jobs/cron/drainInbox.job.ts
@@ -1,0 +1,44 @@
+import { logger, taggedMessaged } from '../../../helpers/logger';
+import { drainInbox } from '../../../../modules/Inbox/processor';
+import { isInboxEnabled } from '../../../../modules/Inbox/config';
+
+/**
+ * The reverse-inbox drainer's scheduled entry point (ADR-0018, ADR-0023, ADR-0025 §6b).
+ *
+ * The HTTP endpoint only VERIFIES and RECORDS an instruction (ACK-on-commit); this job is what
+ * APPLIES the PENDING rows — flipping payment_status — off the request path, so a slow apply never
+ * blocks the ACK. A missed tick loses nothing: the row stays PENDING and the next tick applies it,
+ * which is the whole point of the inbox table being the durability boundary.
+ *
+ * Gated by EMR_INBOX_ENABLED, so with the flag off this is a cheap no-op.
+ */
+export const drainInboxJob = async (): Promise<void> => {
+  const message = taggedMessaged('DrainInbox');
+
+  if (!isInboxEnabled()) {
+    return;
+  }
+
+  try {
+    const result = await drainInbox();
+    if (result.claimed > 0) {
+      logger.notice(
+        message(
+          `Drained inbox: claimed ${result.claimed}, applied ${result.applied}, ` +
+            `discarded ${result.discarded}, unhandled ${result.unhandled}, failed ${result.failed}`
+        )
+      );
+    }
+    if (result.failed > 0) {
+      // Surfacing, not swallowing: a failed instruction is money Accounting recorded that the EMR
+      // could not act on — a paying patient's gate may stay shut. It is dead-lettered for replay,
+      // but an operator must know.
+      logger.error(
+        message(`${result.failed} inbox instruction(s) dead-lettered and need attention`)
+      );
+    }
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    logger.error(message(`Inbox drain pass failed: ${detail}`));
+  }
+};

--- a/server/src/core/command/jobs/index.ts
+++ b/server/src/core/command/jobs/index.ts
@@ -10,3 +10,4 @@ export { closeAntenatalAccount } from './cron/closeAntenatalAccount.job';
 export { endVisits } from './cron/endVisits.job';
 export { createPatientInsuranceAccount } from './now/createPatientInsurance.job';
 export { drainOutbox } from './cron/drainOutbox.job';
+export { drainInboxJob } from './cron/drainInbox.job';

--- a/server/src/core/command/worker/jobDefinition.ts
+++ b/server/src/core/command/worker/jobDefinition.ts
@@ -10,6 +10,7 @@ import {
   closeAntenatalAccount,
   endVisits,
   drainOutbox,
+  drainInboxJob,
 } from '../jobs';
 import { logger } from '../../helpers/logger';
 import dayjs from 'dayjs';
@@ -24,6 +25,7 @@ const Jobs = {
   [JobName.CLOSE_ANTENATAL_ACCOUNT]: closeAntenatalAccount,
   [JobName.END_VISIT]: endVisits,
   [JobName.DRAIN_OUTBOX]: drainOutbox,
+  [JobName.DRAIN_INBOX]: drainInboxJob,
 };
 
 const setFailureBehavior = (agenda: Agenda, jobName: string) => {

--- a/server/src/core/startup/loaders.ts
+++ b/server/src/core/startup/loaders.ts
@@ -7,6 +7,7 @@ import morgan from 'morgan';
 import bodyParser from 'body-parser';
 import { RequestHandler } from 'express-serve-static-core';
 import { ParsedQs } from 'qs';
+import inboxRoutes from '../../modules/Inbox/inbox.routes';
 // import agenda from '../command/agenda';
 // import serveStatic from 'serve-static';
 
@@ -21,6 +22,10 @@ export default (
   server.use(helmet());
   server.use(cors({ credentials: true, origin: [], optionsSuccessStatus: 200 }));
   server.use(morgan('dev'));
+  // Mounted BEFORE the global JSON parser: the reverse inbox verifies an HMAC over the RAW request
+  // bytes (ADR-0025 §5), so its route-scoped raw parser must see the body before bodyParser.json()
+  // re-parses it. No other route is affected.
+  server.use('/api/integration/accounting', inboxRoutes);
   server.use(bodyParser.json({ limit: '50mb' }));
   server.use(bodyParser.urlencoded({ extended: true }));
   server.use(express.static('download'));

--- a/server/src/database/migrations/20260723000000-create-inbox-events.js
+++ b/server/src/database/migrations/20260723000000-create-inbox-events.js
@@ -1,0 +1,130 @@
+'use strict';
+
+/**
+ * The Accounting → EMR transactional inbox (issue #4 Phase B2; ADR-0018, ADR-0023, ADR-0025 §6b).
+ *
+ * Mirror of the outbox on the receiving side: a verified instruction is written to Inbox_Events and
+ * committed before the endpoint ACKs; a drain step applies it (flipping payment_status). Durability
+ * lives in the table, not a queue. Lands additive — no existing table is touched.
+ */
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('Inbox_Events', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.BIGINT,
+      },
+      event_id: {
+        type: Sequelize.STRING(64),
+        allowNull: false,
+        unique: true,
+      },
+      // Dedup guard. UNIQUE is what makes a redelivered instruction impossible to apply twice.
+      idempotency_key: {
+        type: Sequelize.STRING(200),
+        allowNull: false,
+        unique: true,
+      },
+      event_type: {
+        type: Sequelize.STRING(64),
+        allowNull: false,
+      },
+      event_version: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        defaultValue: 1,
+      },
+      aggregate_type: {
+        type: Sequelize.STRING(64),
+        allowNull: false,
+      },
+      aggregate_id: {
+        type: Sequelize.STRING(64),
+        allowNull: false,
+      },
+      // Monotonic per aggregate, NOT gapless. Never assert contiguity.
+      sequence: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+      },
+      status: {
+        type: Sequelize.STRING(16),
+        allowNull: false,
+        defaultValue: 'PENDING',
+      },
+      // IDs and money-as-string only. No demographics (ADR-0016).
+      payload: {
+        type: Sequelize.JSON,
+        allowNull: false,
+      },
+      key_id: {
+        type: Sequelize.STRING(64),
+        allowNull: false,
+      },
+      processed_at: {
+        type: Sequelize.DATE,
+        allowNull: true,
+      },
+      attempts: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        defaultValue: 0,
+      },
+      createdAt: { allowNull: false, type: Sequelize.DATE },
+      updatedAt: { allowNull: false, type: Sequelize.DATE },
+    });
+
+    // The drainer's only query: PENDING rows, oldest first.
+    await queryInterface.addIndex('Inbox_Events', ['status', 'id'], {
+      name: 'idx_inbox_events_pending',
+    });
+
+    // Gap detection reads the per-aggregate sequence run.
+    await queryInterface.addIndex('Inbox_Events', ['aggregate_type', 'aggregate_id', 'sequence'], {
+      name: 'idx_inbox_events_aggregate',
+    });
+
+    await queryInterface.createTable('Inbox_Dead_Letters', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.BIGINT,
+      },
+      event_id: { type: Sequelize.STRING(64), allowNull: true },
+      event_type: { type: Sequelize.STRING(64), allowNull: true },
+      // NOT unique: the same instruction may legitimately fail across redeliveries, and a unique
+      // constraint would throw while recording a failure.
+      idempotency_key: { type: Sequelize.STRING(200), allowNull: true },
+      reason: { type: Sequelize.STRING(64), allowNull: false },
+      detail: { type: Sequelize.TEXT, allowNull: false },
+      payload: { type: Sequelize.JSON, allowNull: false },
+      inbox_event_id: { type: Sequelize.BIGINT, allowNull: true },
+      createdAt: { allowNull: false, type: Sequelize.DATE },
+      updatedAt: { allowNull: false, type: Sequelize.DATE },
+    });
+
+    await queryInterface.createTable('Inbox_Sequences', {
+      aggregate_id: {
+        allowNull: false,
+        primaryKey: true,
+        type: Sequelize.STRING(64),
+      },
+      last_applied_sequence: {
+        type: Sequelize.BIGINT,
+        allowNull: false,
+        defaultValue: 0,
+      },
+      createdAt: { allowNull: false, type: Sequelize.DATE },
+      updatedAt: { allowNull: false, type: Sequelize.DATE },
+    });
+  },
+
+  down: async queryInterface => {
+    await queryInterface.dropTable('Inbox_Events');
+    await queryInterface.dropTable('Inbox_Dead_Letters');
+    await queryInterface.dropTable('Inbox_Sequences');
+  },
+};

--- a/server/src/database/models/inboxDeadLetter.ts
+++ b/server/src/database/models/inboxDeadLetter.ts
@@ -1,0 +1,41 @@
+import { Column, DataType, Model, PrimaryKey, Table } from 'sequelize-typescript';
+
+/**
+ * The reverse-inbox dead-letter store (ADR-0025 §7). An instruction that is authenticated but
+ * cannot be applied lands here with its FULL payload and a structured reason — never dropped,
+ * never retried forever.
+ *
+ * Load-bearing: a silently-dropped `payment.settled` means a paying patient's gate never opens
+ * (money taken, drugs withheld). This table is what B2.4 renders and replays.
+ *
+ * `idempotency_key` is deliberately NOT unique: the same instruction may legitimately fail across
+ * redeliveries, and a unique constraint would throw while RECORDING a failure — losing it at the
+ * exact moment we try to preserve it.
+ */
+@Table({ timestamps: true, tableName: 'Inbox_Dead_Letters' })
+export class InboxDeadLetter extends Model {
+  @PrimaryKey
+  @Column({ type: DataType.BIGINT, allowNull: false, autoIncrement: true })
+  id: number;
+
+  @Column({ type: DataType.STRING(64), allowNull: true })
+  event_id: string;
+
+  @Column({ type: DataType.STRING(64), allowNull: true })
+  event_type: string;
+
+  @Column({ type: DataType.STRING(200), allowNull: true })
+  idempotency_key: string;
+
+  @Column({ type: DataType.STRING(64), allowNull: false })
+  reason: string;
+
+  @Column({ type: DataType.TEXT, allowNull: false })
+  detail: string;
+
+  @Column({ type: DataType.JSON, allowNull: false })
+  payload: Record<string, unknown>;
+
+  @Column({ type: DataType.BIGINT, allowNull: true })
+  inbox_event_id: number;
+}

--- a/server/src/database/models/inboxEvent.ts
+++ b/server/src/database/models/inboxEvent.ts
@@ -1,0 +1,61 @@
+import { Column, DataType, Model, PrimaryKey, Table } from 'sequelize-typescript';
+
+/**
+ * The transactional INBOX for Accounting → EMR instructions (ADR-0018, ADR-0023, ADR-0025 §6b).
+ * The mirror of `OutboxEvent` on the receiving side.
+ *
+ * A verified instruction is written here and COMMITTED before the endpoint ACKs, so an ACK means
+ * "we will not lose this", not "we have applied it". A separate drain step reads PENDING rows and
+ * applies the effect (flipping `payment_status` on the named prescribed line). Durability lives in
+ * this table, never in a queue: a crash after the ACK leaves the row PENDING and the next drain
+ * picks it up.
+ *
+ * `payload` holds the full received envelope. IDs and money-as-string only — no demographics
+ * (ADR-0016). `idempotency_key` UNIQUE is the dedup guard: a redelivered instruction hits the
+ * constraint and is recognised as already-seen rather than applied twice.
+ */
+@Table({ timestamps: true, tableName: 'Inbox_Events' })
+export class InboxEvent extends Model {
+  @PrimaryKey
+  @Column({ type: DataType.BIGINT, allowNull: false, autoIncrement: true })
+  id: number;
+
+  @Column({ type: DataType.STRING(64), allowNull: false, unique: true })
+  event_id: string;
+
+  /** Deduplicates a redelivery. OPAQUE — stored and compared as a string, never parsed. */
+  @Column({ type: DataType.STRING(200), allowNull: false, unique: true })
+  idempotency_key: string;
+
+  @Column({ type: DataType.STRING(64), allowNull: false })
+  event_type: string;
+
+  @Column({ type: DataType.INTEGER, allowNull: false, defaultValue: 1 })
+  event_version: number;
+
+  @Column({ type: DataType.STRING(64), allowNull: false })
+  aggregate_type: string;
+
+  @Column({ type: DataType.STRING(64), allowNull: false })
+  aggregate_id: string;
+
+  /** Monotonic per aggregate, NOT gapless — never assert contiguity. */
+  @Column({ type: DataType.BIGINT, allowNull: false })
+  sequence: number;
+
+  /** PENDING → PROCESSED | UNHANDLED | FAILED. */
+  @Column({ type: DataType.STRING(16), allowNull: false, defaultValue: 'PENDING' })
+  status: string;
+
+  @Column({ type: DataType.JSON, allowNull: false })
+  payload: Record<string, unknown>;
+
+  @Column({ type: DataType.STRING(64), allowNull: false })
+  key_id: string;
+
+  @Column({ type: DataType.DATE, allowNull: true })
+  processed_at: Date;
+
+  @Column({ type: DataType.INTEGER, allowNull: false, defaultValue: 0 })
+  attempts: number;
+}

--- a/server/src/database/models/inboxSequence.ts
+++ b/server/src/database/models/inboxSequence.ts
@@ -1,0 +1,25 @@
+import { Column, DataType, Model, PrimaryKey, Table } from 'sequelize-typescript';
+
+/**
+ * Per-aggregate high-water marks for APPLIED overwrite instructions on the inbox (ADR-0025 §4).
+ *
+ * The reverse events are OVERWRITE events: `payment.settled` carries a per-encounter sequence, and
+ * a redelivery or a race can present them out of order. This row records the highest sequence
+ * already APPLIED for an aggregate, so an instruction with a lower-or-equal sequence is discarded
+ * as stale rather than overwriting a fresher state (the delayed `unpaid` that must not clobber a
+ * later `paid`).
+ *
+ * Monotonic, NOT gapless — a gap is normal (the sender's clinical transaction may have rolled back
+ * a number). Never assert contiguity.
+ *
+ * Bookkeeping about EVENT ORDERING, never about money.
+ */
+@Table({ timestamps: true, tableName: 'Inbox_Sequences' })
+export class InboxSequence extends Model {
+  @PrimaryKey
+  @Column({ type: DataType.STRING(64), allowNull: false })
+  aggregate_id: string;
+
+  @Column({ type: DataType.BIGINT, allowNull: false, defaultValue: 0 })
+  last_applied_sequence: number;
+}

--- a/server/src/database/models/index.ts
+++ b/server/src/database/models/index.ts
@@ -83,3 +83,6 @@ export { WardRound } from './wardRound';
 // of the model<->helper<->repository import cycle that the earlier entries participate in.
 export { OutboxEvent } from './outboxEvent';
 export { OutboxSequence } from './outboxSequence';
+export { InboxEvent } from './inboxEvent';
+export { InboxDeadLetter } from './inboxDeadLetter';
+export { InboxSequence } from './inboxSequence';

--- a/server/src/modules/Inbox/applier.test.ts
+++ b/server/src/modules/Inbox/applier.test.ts
@@ -1,0 +1,184 @@
+import '../../core/config/env';
+import { QueryTypes } from 'sequelize';
+import { sequelizeConnection } from '../../database/config/data-source';
+import { PaymentStatus } from '../../database/enums';
+import { InboxSequence } from '../../database/models/inboxSequence';
+import { applyInstruction } from './applier';
+import { isReleased } from './gate';
+
+/**
+ * Integration tests for the applier and the gate, against real MySQL. The claims — that the flip
+ * touches ONLY payment_status, is sequence-guarded, never un-dispenses, and that the gate reads the
+ * recorded status and fails safe — are claims about the DATABASE and the real Prescribed_* schema,
+ * so they run against it, not a mock.
+ *
+ * A minimal Prescribed_Drugs row is seeded with FK checks off (a fixture technique — the applier's
+ * UPDATE is by primary key and touches no FK column, so the parent rows are irrelevant to what is
+ * under test).
+ */
+
+const DRUG_ID = 990001;
+const VISIT_ID = 8891;
+const AGG = `visit:${VISIT_ID}`;
+
+async function seedDrug(paymentStatus: PaymentStatus, dispensed = 0): Promise<void> {
+  // SET FOREIGN_KEY_CHECKS is SESSION-scoped, and Sequelize pools connections — so the SET and the
+  // INSERT must share ONE connection or the insert can hit a connection where checks are still on.
+  // A single transaction pins them to the same connection.
+  await sequelizeConnection.transaction(async transaction => {
+    await sequelizeConnection.query('SET FOREIGN_KEY_CHECKS=0', { raw: true, transaction });
+    await sequelizeConnection.query(
+      `INSERT INTO Prescribed_Drugs
+         (id, drug_id, dosage_form_id, drug_type, quantity_prescribed, quantity_to_dispense,
+          quantity_dispensed, route_id, frequency, strength_id, duration, total_price, examiner,
+          date_prescribed, prescribed_strength, duration_unit, visit_id, patient_id, start_date,
+          drug_prescription_id, inventory_id, payment_status, createdAt, updatedAt)
+       VALUES
+         (:id, 1, 1, 'Cash', 2, 2, :dispensed, 1, 'BD', 1, 5, '2500.00', 1, NOW(), '500mg', 'days',
+          :visit, 100, NOW(), 1, 1, :status, NOW(), NOW())`,
+      {
+        replacements: { id: DRUG_ID, dispensed, visit: VISIT_ID, status: paymentStatus },
+        type: QueryTypes.INSERT,
+        transaction,
+      }
+    );
+  });
+}
+
+async function deleteDrug(): Promise<void> {
+  await sequelizeConnection.transaction(async transaction => {
+    await sequelizeConnection.query('SET FOREIGN_KEY_CHECKS=0', { raw: true, transaction });
+    await sequelizeConnection.query(`DELETE FROM Prescribed_Drugs WHERE id = :id`, {
+      replacements: { id: DRUG_ID },
+      type: QueryTypes.DELETE,
+      transaction,
+    });
+  });
+}
+
+async function readDrug(): Promise<{ payment_status: string; quantity_dispensed: number }> {
+  const [row] = await sequelizeConnection.query<{
+    payment_status: string;
+    quantity_dispensed: number;
+  }>(`SELECT payment_status, quantity_dispensed FROM Prescribed_Drugs WHERE id = :id`, {
+    replacements: { id: DRUG_ID },
+    type: QueryTypes.SELECT,
+  });
+  return row;
+}
+
+function settledBody() {
+  return { external_line_ref: { type: 'drug', id: String(DRUG_ID) }, encounter_id: AGG };
+}
+
+describe('applier + gate (B2.2 / B2.3)', () => {
+  afterAll(async () => {
+    await deleteDrug();
+    await sequelizeConnection.close();
+  });
+
+  beforeEach(async () => {
+    await InboxSequence.destroy({ where: {}, truncate: true, force: true });
+    await deleteDrug();
+  });
+
+  it('payment.settled flips payment_status to Paid and touches nothing else', async () => {
+    await seedDrug(PaymentStatus.PENDING, 0);
+
+    const result = await sequelizeConnection.transaction(t =>
+      applyInstruction('payment.settled', AGG, 1, settledBody(), t)
+    );
+
+    expect(result.outcome).toBe('APPLIED');
+    const drug = await readDrug();
+    expect(drug.payment_status).toBe(PaymentStatus.PAID);
+    // Decision 9: no dispense side-effect. quantity_dispensed is untouched.
+    expect(Number(drug.quantity_dispensed)).toBe(0);
+  });
+
+  it('is idempotent by sequence: a resent settle at the same sequence is discarded, status stays', async () => {
+    await seedDrug(PaymentStatus.PENDING, 0);
+
+    const first = await sequelizeConnection.transaction(t =>
+      applyInstruction('payment.settled', AGG, 5, settledBody(), t)
+    );
+    const resend = await sequelizeConnection.transaction(t =>
+      applyInstruction('payment.settled', AGG, 5, settledBody(), t)
+    );
+
+    expect(first.outcome).toBe('APPLIED');
+    expect(resend.outcome).toBe('DISCARDED_STALE');
+    expect((await readDrug()).payment_status).toBe(PaymentStatus.PAID);
+  });
+
+  it('a stale refund for an ALREADY-DISPENSED line changes only payment_status, never un-dispenses', async () => {
+    // Paid and fully dispensed. A LATE refund (lower sequence than the settle) must be discarded.
+    await seedDrug(PaymentStatus.PAID, 2);
+
+    const settle = await sequelizeConnection.transaction(t =>
+      applyInstruction('payment.settled', AGG, 10, settledBody(), t)
+    );
+    const staleRefund = await sequelizeConnection.transaction(t =>
+      applyInstruction('payment.refunded', AGG, 4, settledBody(), t)
+    );
+
+    expect(settle.outcome).toBe('APPLIED');
+    expect(staleRefund.outcome).toBe('DISCARDED_STALE');
+    const drug = await readDrug();
+    expect(drug.payment_status).toBe(PaymentStatus.PAID);
+    // Never un-dispensed (Q6b.4).
+    expect(Number(drug.quantity_dispensed)).toBe(2);
+  });
+
+  it('a fresh refund reverts payment_status to Pending, still never un-dispensing', async () => {
+    await seedDrug(PaymentStatus.PAID, 2);
+
+    await sequelizeConnection.transaction(t =>
+      applyInstruction('payment.settled', AGG, 1, settledBody(), t)
+    );
+    const refund = await sequelizeConnection.transaction(t =>
+      applyInstruction('payment.refunded', AGG, 2, settledBody(), t)
+    );
+
+    expect(refund.outcome).toBe('APPLIED');
+    const drug = await readDrug();
+    expect(drug.payment_status).toBe(PaymentStatus.PENDING);
+    expect(Number(drug.quantity_dispensed)).toBe(2);
+  });
+
+  it('a valid-but-unhandled reverse type is UNHANDLED, not applied and not failed', async () => {
+    await seedDrug(PaymentStatus.PENDING, 0);
+
+    const result = await sequelizeConnection.transaction(t =>
+      applyInstruction('authorisation.rejected', AGG, 1, settledBody(), t)
+    );
+
+    expect(result.outcome).toBe('UNHANDLED');
+    expect((await readDrug()).payment_status).toBe(PaymentStatus.PENDING);
+  });
+
+  describe('gate (B2.3) fails safe', () => {
+    it('HOLDS while payment_status is Pending (stale/unpaid)', async () => {
+      await seedDrug(PaymentStatus.PENDING, 0);
+      const decision = await isReleased('drug', DRUG_ID);
+      expect(decision.released).toBe(false);
+      expect(decision.status).toBe(PaymentStatus.PENDING);
+    });
+
+    it('RELEASES once a settle has been applied', async () => {
+      await seedDrug(PaymentStatus.PENDING, 0);
+      await sequelizeConnection.transaction(t =>
+        applyInstruction('payment.settled', AGG, 1, settledBody(), t)
+      );
+      const decision = await isReleased('drug', DRUG_ID);
+      expect(decision.released).toBe(true);
+      expect(decision.status).toBe(PaymentStatus.PAID);
+    });
+
+    it('HOLDS for a line that does not exist, never releasing on missing data', async () => {
+      const decision = await isReleased('drug', 424242);
+      expect(decision.released).toBe(false);
+      expect(decision.status).toBeNull();
+    });
+  });
+});

--- a/server/src/modules/Inbox/applier.ts
+++ b/server/src/modules/Inbox/applier.ts
@@ -1,0 +1,159 @@
+import { ModelStatic, Model, Transaction } from 'sequelize';
+import { PaymentStatus } from '../../database/enums';
+import { PrescribedDrug } from '../../database/models/prescribedDrug';
+import { PrescribedInvestigation } from '../../database/models/prescribedInvestigation';
+import { PrescribedService } from '../../database/models/prescribedService';
+import { PrescribedTest } from '../../database/models/prescribedTest';
+import { PrescribedAdditionalItem } from '../../database/models/prescribedAdditionalItem';
+import { InboxSequence } from '../../database/models/inboxSequence';
+import { isPrescribedLineType, PrescribedLineType } from '../Outbox/prescribed-line-types';
+
+/**
+ * Applies a verified reverse instruction to the EMR's OWN rows (ADR-0023, ADR-0025 §6b).
+ *
+ * THE LOAD-BEARING INVARIANT: the EMR writes; Accounting never writes this column. There is
+ * deliberately no "Accounting UPDATEs the EMR's MySQL" path — that is ADR-0011's lethal shortcut in
+ * mirror image, made tempting by co-location. Everything money-facing about a prescribed line's
+ * payment state is set HERE, off a verified instruction, and nowhere else.
+ *
+ * DECISION 9 — NO automated dispense side-effect. Applying `payment.settled` flips `payment_status`
+ * and NOTHING else. The physical dispense is a human clinical action a pharmacist takes after
+ * SEEING the gate open; an event must never hand out drugs. A refund likewise never un-dispenses
+ * (Q6b.4): it changes `payment_status` only, even for an already-dispensed line.
+ */
+
+const MODEL_BY_TYPE: Record<PrescribedLineType, ModelStatic<Model>> = {
+  drug: (PrescribedDrug as unknown) as ModelStatic<Model>,
+  investigation: (PrescribedInvestigation as unknown) as ModelStatic<Model>,
+  service: (PrescribedService as unknown) as ModelStatic<Model>,
+  test: (PrescribedTest as unknown) as ModelStatic<Model>,
+  additional_item: (PrescribedAdditionalItem as unknown) as ModelStatic<Model>,
+};
+
+export type ApplyResult =
+  | { readonly outcome: 'APPLIED' }
+  | { readonly outcome: 'DISCARDED_STALE' }
+  | { readonly outcome: 'UNHANDLED' };
+
+export class ApplyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ApplyError';
+  }
+}
+
+interface ExternalLineRef {
+  readonly type: unknown;
+  readonly id: unknown;
+}
+
+function readLineRef(body: Record<string, unknown>): { type: PrescribedLineType; id: number } {
+  const ref = body.external_line_ref as ExternalLineRef | undefined;
+  if (ref === undefined || typeof ref !== 'object' || ref === null) {
+    throw new ApplyError('instruction body is missing external_line_ref.');
+  }
+  if (!isPrescribedLineType(ref.type)) {
+    throw new ApplyError(
+      `unknown external_line_ref.type "${String(ref.type)}"; not one of the five prescribed types.`
+    );
+  }
+  const id = Number(ref.id);
+  if (!Number.isInteger(id) || id <= 0) {
+    throw new ApplyError(
+      `external_line_ref.id must be a positive integer, got "${String(ref.id)}".`
+    );
+  }
+  return { type: ref.type, id };
+}
+
+/**
+ * Discards an overwrite instruction whose sequence is not higher than the one already applied for
+ * its aggregate. The high-water row is locked FOR UPDATE and advanced in the same transaction as
+ * the effect, so two concurrent instructions for one encounter cannot both apply out of order.
+ *
+ * Returns true if this instruction should proceed (it advanced the mark), false if it is stale.
+ */
+async function claimSequence(
+  aggregateId: string,
+  sequence: number,
+  transaction: Transaction
+): Promise<boolean> {
+  const [row] = await InboxSequence.findOrCreate({
+    where: { aggregate_id: aggregateId },
+    defaults: { aggregate_id: aggregateId, last_applied_sequence: 0 } as never,
+    lock: transaction.LOCK.UPDATE,
+    transaction,
+  });
+
+  const applied = Number(
+    ((row as unknown) as { last_applied_sequence: number }).last_applied_sequence
+  );
+  if (sequence <= applied) {
+    return false;
+  }
+
+  await InboxSequence.update({ last_applied_sequence: sequence } as never, {
+    where: { aggregate_id: aggregateId },
+    transaction,
+  });
+  return true;
+}
+
+/**
+ * Applies one instruction on the caller's transaction. The dedup (inbox idempotency key) and the
+ * status flip commit together, so a crash never leaves one without the other.
+ */
+export async function applyInstruction(
+  eventType: string,
+  aggregateId: string,
+  sequence: number,
+  body: Record<string, unknown>,
+  transaction: Transaction
+): Promise<ApplyResult> {
+  const nextStatus = statusFor(eventType);
+  if (nextStatus === undefined) {
+    // A valid reverse event whose handling has not landed (authorisation.rejected, stock.received).
+    // Not a failure and not applied — recorded UNHANDLED, exactly as Accounting does inbound.
+    return { outcome: 'UNHANDLED' };
+  }
+
+  // Overwrite semantics: discard a stale sequence rather than clobbering a fresher state.
+  const fresh = await claimSequence(aggregateId, sequence, transaction);
+  if (!fresh) {
+    return { outcome: 'DISCARDED_STALE' };
+  }
+
+  const { type, id } = readLineRef(body);
+  const model = MODEL_BY_TYPE[type];
+
+  // Existence is checked by a read, NOT by the UPDATE's affected-row count: MySQL reports 0 rows
+  // affected when the new value equals the current one (settling an already-Paid line), which would
+  // otherwise be misread as "the line does not exist" and wrongly dead-letter a valid instruction.
+  const existing = await model.findByPk(id, { transaction });
+  if (existing === null) {
+    throw new ApplyError(
+      `no ${type} row with id ${id} to apply ${eventType} to — the line the instruction names does not exist.`
+    );
+  }
+
+  // ONLY payment_status. No dispense field, no quantity, no returned-flag — decision 9. A refund
+  // reverts to Pending and still never touches dispense state (Q6b.4).
+  await model.update({ payment_status: nextStatus } as never, {
+    where: { id },
+    transaction,
+  });
+
+  return { outcome: 'APPLIED' };
+}
+
+/** The status a reverse event sets, or undefined for a valid-but-unhandled reverse type. */
+function statusFor(eventType: string): PaymentStatus | undefined {
+  switch (eventType) {
+    case 'payment.settled':
+      return PaymentStatus.PAID;
+    case 'payment.refunded':
+      return PaymentStatus.PENDING;
+    default:
+      return undefined;
+  }
+}

--- a/server/src/modules/Inbox/config.ts
+++ b/server/src/modules/Inbox/config.ts
@@ -1,0 +1,33 @@
+import { VerifierConfig, VerificationKey } from './verifier';
+
+/**
+ * Reads the reverse-inbox verification config from the environment.
+ *
+ * PLACEHOLDER, like the outbox keys: ADR-0023 co-provisions these into local secret storage when
+ * the EMR and Accounting are installed together; no slice has built that storage, so they arrive as
+ * env for now. `EMR_INBOUND_KEY_ID`/`EMR_INBOUND_SECRET` are the key ACCOUNTING signs the reverse
+ * direction with — a SEPARATE key from the outbox's outbound key (ADR-0025 Q5.5).
+ */
+
+export function isInboxEnabled(): boolean {
+  return process.env.EMR_INBOX_ENABLED === 'true';
+}
+
+const DEFAULT_MAX_SKEW_SECONDS = 300;
+
+export function readVerifierConfig(): VerifierConfig {
+  const keyId = process.env.EMR_INBOUND_KEY_ID;
+  const secret = process.env.EMR_INBOUND_SECRET;
+  const expectedTenantKey = process.env.EMR_TENANT_KEY;
+
+  if (!keyId || !secret || !expectedTenantKey) {
+    throw new Error(
+      'Inbox misconfigured: set EMR_INBOUND_KEY_ID, EMR_INBOUND_SECRET, EMR_TENANT_KEY.'
+    );
+  }
+
+  const keys: VerificationKey[] = [{ keyId, secret }];
+  const maxSkewSeconds = Number(process.env.EMR_EVENT_MAX_SKEW_SECONDS || DEFAULT_MAX_SKEW_SECONDS);
+
+  return { keys, expectedTenantKey, maxSkewSeconds };
+}

--- a/server/src/modules/Inbox/gate.ts
+++ b/server/src/modules/Inbox/gate.ts
@@ -1,0 +1,65 @@
+import { ModelStatic, Model } from 'sequelize';
+import { PaymentStatus } from '../../database/enums';
+import { PrescribedDrug } from '../../database/models/prescribedDrug';
+import { PrescribedInvestigation } from '../../database/models/prescribedInvestigation';
+import { PrescribedService } from '../../database/models/prescribedService';
+import { PrescribedTest } from '../../database/models/prescribedTest';
+import { PrescribedAdditionalItem } from '../../database/models/prescribedAdditionalItem';
+import { isPrescribedLineType, PrescribedLineType } from '../Outbox/prescribed-line-types';
+
+/**
+ * The pharmacy/discharge GATE reads the RECORDED payment_status and fails safe (ADR-0023).
+ *
+ * A line releases only on a payment_status the reverse inbox has already applied. While that
+ * projection is stale — the reverse channel is paused, an instruction has not drained yet — the
+ * gate HOLDS. That is the correct failure direction: holding a paid patient's drugs briefly is
+ * recoverable; releasing an unpaid patient's drugs is not.
+ *
+ * There is deliberately NO synchronous counter→EMR write to "freshen" the status on demand: that
+ * would make Accounting's commit wait on a cross-engine HTTP write and let a slow EMR block the
+ * cashier from taking money. The gate reads only what has already been durably recorded here.
+ */
+
+const MODEL_BY_TYPE: Record<PrescribedLineType, ModelStatic<Model>> = {
+  drug: (PrescribedDrug as unknown) as ModelStatic<Model>,
+  investigation: (PrescribedInvestigation as unknown) as ModelStatic<Model>,
+  service: (PrescribedService as unknown) as ModelStatic<Model>,
+  test: (PrescribedTest as unknown) as ModelStatic<Model>,
+  additional_item: (PrescribedAdditionalItem as unknown) as ModelStatic<Model>,
+};
+
+/** A status that permits fulfilment. Anything else (notably Pending) HOLDS the gate. */
+const RELEASING_STATUSES: ReadonlySet<string> = new Set([
+  PaymentStatus.PAID,
+  PaymentStatus.CLEARED,
+  PaymentStatus.PERMITTED,
+]);
+
+export interface GateDecision {
+  readonly released: boolean;
+  readonly status: string | null;
+}
+
+/**
+ * Whether a prescribed line may be fulfilled, by its recorded payment_status. A line that does not
+ * exist, or whose status is not yet a releasing one, HOLDS (released: false) — never releases on
+ * missing or stale data.
+ */
+export async function isReleased(type: unknown, id: unknown): Promise<GateDecision> {
+  if (!isPrescribedLineType(type)) {
+    return { released: false, status: null };
+  }
+  const lineId = Number(id);
+  if (!Number.isInteger(lineId) || lineId <= 0) {
+    return { released: false, status: null };
+  }
+
+  const model = MODEL_BY_TYPE[type];
+  const row = await model.findByPk(lineId);
+  if (row === null) {
+    return { released: false, status: null };
+  }
+
+  const status = ((row as unknown) as { payment_status: string }).payment_status;
+  return { released: RELEASING_STATUSES.has(status), status };
+}

--- a/server/src/modules/Inbox/inbox-pipeline.test.ts
+++ b/server/src/modules/Inbox/inbox-pipeline.test.ts
@@ -1,0 +1,195 @@
+import '../../core/config/env';
+import { QueryTypes } from 'sequelize';
+import { sequelizeConnection } from '../../database/config/data-source';
+import { PaymentStatus } from '../../database/enums';
+import { InboxEvent } from '../../database/models/inboxEvent';
+import { InboxDeadLetter } from '../../database/models/inboxDeadLetter';
+import { InboxSequence } from '../../database/models/inboxSequence';
+import { signEvent } from '../Outbox/signer';
+import { VerifierConfig } from './verifier';
+import { verifyAndWrite } from './inbox-writer';
+import { processOne, drainInbox } from './processor';
+
+/**
+ * End-to-end reverse-inbox pipeline against real MySQL (B2.1 / B2.2 / B2.4): a signed instruction
+ * is verified, written to the inbox, drained, and applied to the prescribed row — and the failure
+ * paths (bad signature written nowhere, duplicate deduped, un-appliable instruction dead-lettered)
+ * are proven, not asserted.
+ */
+
+const KEY = { keyId: 'acct-test', secret: 'reverse-test-secret' };
+const TENANT = 'st_vincent';
+const DRUG_ID = 990002;
+const VISIT_ID = 8892;
+const AGG = `visit:${VISIT_ID}`;
+
+const config: VerifierConfig = {
+  keys: [{ keyId: KEY.keyId, secret: KEY.secret }],
+  expectedTenantKey: TENANT,
+  maxSkewSeconds: 300,
+};
+
+let eventCounter = 0;
+function eventId(): string {
+  eventCounter += 1;
+  return `019f8e40-0000-7000-8000-${String(eventCounter).padStart(12, '0')}`;
+}
+
+function signedSettle(
+  overrides: {
+    sequence?: number;
+    idempotencyKey?: string;
+    lineId?: number;
+    eventType?: string;
+  } = {}
+): { rawBody: string; headers: Record<string, string> } {
+  const sentAt = new Date().toISOString();
+  const envelope = {
+    event_id: eventId(),
+    event_type: overrides.eventType ?? 'payment.settled',
+    event_version: 1,
+    tenant_key: TENANT,
+    occurred_at: sentAt,
+    sent_at: sentAt,
+    aggregate: { type: 'reverse_encounter', id: AGG },
+    sequence: overrides.sequence ?? 1,
+    idempotency_key: overrides.idempotencyKey ?? `settled:${overrides.lineId ?? DRUG_ID}`,
+    body: {
+      external_line_ref: { type: 'drug', id: String(overrides.lineId ?? DRUG_ID) },
+      encounter_id: AGG,
+      amount_kobo: '250000',
+      settled_at: sentAt,
+    },
+  };
+  return signEvent(envelope, KEY);
+}
+
+async function seedDrug(): Promise<void> {
+  await sequelizeConnection.transaction(async transaction => {
+    await sequelizeConnection.query('SET FOREIGN_KEY_CHECKS=0', { raw: true, transaction });
+    await sequelizeConnection.query(
+      `INSERT INTO Prescribed_Drugs
+         (id, drug_id, dosage_form_id, drug_type, quantity_prescribed, quantity_to_dispense,
+          quantity_dispensed, route_id, frequency, strength_id, duration, total_price, examiner,
+          date_prescribed, prescribed_strength, duration_unit, visit_id, patient_id, start_date,
+          drug_prescription_id, inventory_id, payment_status, createdAt, updatedAt)
+       VALUES
+         (:id, 1, 1, 'Cash', 2, 2, 0, 1, 'BD', 1, 5, '2500.00', 1, NOW(), '500mg', 'days',
+          :visit, 100, NOW(), 1, 1, 'Pending', NOW(), NOW())`,
+      { replacements: { id: DRUG_ID, visit: VISIT_ID }, type: QueryTypes.INSERT, transaction }
+    );
+  });
+}
+
+async function drugStatus(): Promise<string> {
+  const [row] = await sequelizeConnection.query<{ payment_status: string }>(
+    `SELECT payment_status FROM Prescribed_Drugs WHERE id = :id`,
+    { replacements: { id: DRUG_ID }, type: QueryTypes.SELECT }
+  );
+  return row.payment_status;
+}
+
+describe('reverse inbox pipeline (B2.1 / B2.2 / B2.4)', () => {
+  afterAll(async () => {
+    await sequelizeConnection.transaction(async transaction => {
+      await sequelizeConnection.query('SET FOREIGN_KEY_CHECKS=0', { raw: true, transaction });
+      await sequelizeConnection.query(`DELETE FROM Prescribed_Drugs WHERE id = :id`, {
+        replacements: { id: DRUG_ID },
+        type: QueryTypes.DELETE,
+        transaction,
+      });
+    });
+    await sequelizeConnection.close();
+  });
+
+  beforeEach(async () => {
+    await InboxEvent.destroy({ where: {}, truncate: true, force: true });
+    await InboxDeadLetter.destroy({ where: {}, truncate: true, force: true });
+    await InboxSequence.destroy({ where: {}, truncate: true, force: true });
+    await sequelizeConnection.transaction(async transaction => {
+      await sequelizeConnection.query('SET FOREIGN_KEY_CHECKS=0', { raw: true, transaction });
+      await sequelizeConnection.query(`DELETE FROM Prescribed_Drugs WHERE id = :id`, {
+        replacements: { id: DRUG_ID },
+        type: QueryTypes.DELETE,
+        transaction,
+      });
+    });
+  });
+
+  it('verifies, writes, drains and applies a signed settle end to end', async () => {
+    await seedDrug();
+    const signed = signedSettle();
+
+    const write = await verifyAndWrite(Buffer.from(signed.rawBody, 'utf8'), signed.headers, config);
+    expect(write.result).toBe('ACCEPTED');
+
+    const row = await InboxEvent.findOne({ where: { status: 'PENDING' } });
+    expect(row).not.toBeNull();
+
+    await processOne(row!.id);
+
+    const applied = await InboxEvent.findByPk(row!.id);
+    expect(applied!.status).toBe('PROCESSED');
+    expect(await drugStatus()).toBe(PaymentStatus.PAID);
+  });
+
+  it('rejects a forged signature: 401 semantics, NOTHING written', async () => {
+    const signed = signedSettle();
+    const tampered = Buffer.from(signed.rawBody.replace('250000', '999999'), 'utf8');
+
+    const write = await verifyAndWrite(tampered, signed.headers, config);
+
+    expect(write.result).toBe('REJECTED');
+    expect(write.reason).toBe('SIGNATURE_MISMATCH');
+    expect(await InboxEvent.count()).toBe(0);
+    expect(await InboxDeadLetter.count()).toBe(0);
+  });
+
+  it('dedups a redelivery on the idempotency key: exactly one row, one effect', async () => {
+    await seedDrug();
+    const signed = signedSettle({ idempotencyKey: 'settled:dedup-1' });
+
+    const first = await verifyAndWrite(Buffer.from(signed.rawBody, 'utf8'), signed.headers, config);
+    // A genuine redelivery re-signs with a fresh sent_at (new event_id), same idempotency key.
+    const resigned = signedSettle({ idempotencyKey: 'settled:dedup-1' });
+    const second = await verifyAndWrite(
+      Buffer.from(resigned.rawBody, 'utf8'),
+      resigned.headers,
+      config
+    );
+
+    expect(first.result).toBe('ACCEPTED');
+    expect(second.result).toBe('DUPLICATE');
+    expect(await InboxEvent.count()).toBe(1);
+  });
+
+  it('dead-letters an un-appliable instruction (unknown line) with the full payload; drain continues', async () => {
+    // No drug seeded: the applier cannot find the line, throws, and the row dead-letters.
+    const signed = signedSettle({ lineId: 777777, idempotencyKey: 'settled:missing' });
+    await verifyAndWrite(Buffer.from(signed.rawBody, 'utf8'), signed.headers, config);
+    const row = await InboxEvent.findOne({ where: { status: 'PENDING' } });
+
+    await processOne(row!.id);
+
+    const failed = await InboxEvent.findByPk(row!.id);
+    expect(failed!.status).toBe('FAILED');
+
+    const dead = await InboxDeadLetter.findOne({ where: { inbox_event_id: row!.id } });
+    expect(dead).not.toBeNull();
+    expect(dead!.reason).toBe('HANDLER_ERROR');
+    // Full payload retained for replay.
+    expect((dead!.payload as { external_line_ref: { id: string } }).external_line_ref.id).toBe(
+      '777777'
+    );
+  });
+
+  it('drainInbox applies a batch and reports outcomes', async () => {
+    await seedDrug();
+    const signed = signedSettle({ sequence: 1, idempotencyKey: 'settled:batch-1' });
+    await verifyAndWrite(Buffer.from(signed.rawBody, 'utf8'), signed.headers, config);
+
+    const result = await drainInbox();
+    expect(result.applied).toBe(1);
+    expect(await drugStatus()).toBe(PaymentStatus.PAID);
+  });
+});

--- a/server/src/modules/Inbox/inbox-writer.ts
+++ b/server/src/modules/Inbox/inbox-writer.ts
@@ -1,0 +1,99 @@
+import { UniqueConstraintError } from 'sequelize';
+import { InboxEvent } from '../../database/models/inboxEvent';
+import { verifyReverseSignature, VerifierConfig, VerificationFailure } from './verifier';
+
+/**
+ * Verifies a reverse instruction and writes it to the inbox, committing before the caller ACKs
+ * (ADR-0018: an ACK means "we will not lose this", not "we have applied it").
+ *
+ * Ordering, per the plan:
+ *   - verification failure → the caller returns 401 and NOTHING is written. An unauthenticated
+ *     caller must not be able to fill our tables.
+ *   - a DUPLICATE idempotency key → success (202), no new row. A duplicate is not an error.
+ *   - otherwise the row lands PENDING and a separate drain applies it.
+ */
+
+/** Flat, not a discriminated union — see verifier.ts: this repo compiles with `strict` off. */
+export interface WriteOutcome {
+  readonly result: 'ACCEPTED' | 'DUPLICATE' | 'REJECTED';
+  readonly inboxEventId?: number;
+  readonly reason?: VerificationFailure;
+}
+
+interface Envelope {
+  event_id: string;
+  event_type: string;
+  event_version: number;
+  aggregate: { type: string; id: string };
+  sequence: number;
+  idempotency_key: string;
+  body: Record<string, unknown>;
+}
+
+function readEnvelope(parsed: Record<string, unknown>): Envelope | undefined {
+  const aggregate = parsed.aggregate as { type?: unknown; id?: unknown } | undefined;
+  if (
+    typeof parsed.event_id !== 'string' ||
+    typeof parsed.event_type !== 'string' ||
+    typeof parsed.idempotency_key !== 'string' ||
+    typeof aggregate !== 'object' ||
+    aggregate === null ||
+    typeof aggregate.type !== 'string' ||
+    typeof aggregate.id !== 'string'
+  ) {
+    return undefined;
+  }
+  return {
+    event_id: parsed.event_id,
+    event_type: parsed.event_type,
+    event_version: Number(parsed.event_version ?? 1),
+    aggregate: { type: aggregate.type, id: aggregate.id },
+    sequence: Number(parsed.sequence ?? 0),
+    idempotency_key: parsed.idempotency_key,
+    body: (parsed.body as Record<string, unknown>) ?? {},
+  };
+}
+
+export async function verifyAndWrite(
+  rawBody: Buffer,
+  headers: Record<string, unknown>,
+  config: VerifierConfig,
+  now: Date = new Date()
+): Promise<WriteOutcome> {
+  const verification = verifyReverseSignature(rawBody, headers, config, now);
+  if (!verification.ok) {
+    return { result: 'REJECTED', reason: verification.reason };
+  }
+
+  const envelope = readEnvelope(verification.parsedBody);
+  if (envelope === undefined) {
+    // Authenticated (signature already held) but structurally invalid. Written nowhere here; the
+    // endpoint dead-letters it so a permanently-malformed instruction is recorded once rather than
+    // retried forever. Reason MALFORMED_BODY is what the controller routes to the DLQ.
+    const reason: VerificationFailure = 'MALFORMED_BODY';
+    return { result: 'REJECTED', reason };
+  }
+
+  try {
+    const row = await InboxEvent.create({
+      event_id: envelope.event_id,
+      idempotency_key: envelope.idempotency_key,
+      event_type: envelope.event_type,
+      event_version: envelope.event_version,
+      aggregate_type: envelope.aggregate.type,
+      aggregate_id: envelope.aggregate.id,
+      sequence: envelope.sequence,
+      status: 'PENDING',
+      payload: envelope.body,
+      key_id: verification.keyId,
+    } as never);
+
+    return { result: 'ACCEPTED', inboxEventId: ((row as unknown) as { id: number }).id };
+  } catch (error) {
+    if (error instanceof UniqueConstraintError) {
+      // A redelivery. Recognised-and-discarded: success, no new row.
+      return { result: 'DUPLICATE' };
+    }
+    throw error;
+  }
+}

--- a/server/src/modules/Inbox/inbox.controller.ts
+++ b/server/src/modules/Inbox/inbox.controller.ts
@@ -1,0 +1,66 @@
+import { Request, Response } from 'express';
+import { logger } from '../../core/helpers/logger';
+import { InboxDeadLetter } from '../../database/models/inboxDeadLetter';
+import { isInboxEnabled, readVerifierConfig } from './config';
+import { verifyAndWrite } from './inbox-writer';
+
+/**
+ * The reverse-inbox endpoint: `POST /api/integration/accounting/events` (ADR-0023, ADR-0025 §6b).
+ *
+ * Verify → write Inbox_Events → commit → ACK 202. The ACK is strictly after the row commits, so it
+ * means "we will not lose this". A separate drain applies the effect.
+ *
+ * Status mapping, per the plan:
+ *   - verification failure → 401, NOTHING written (an unauthenticated caller must not fill tables).
+ *   - authenticated but structurally invalid body → dead-letter + 202 (recording a permanently
+ *     malformed instruction once beats an EMR retrying it forever).
+ *   - duplicate idempotency key → 202, no new row (a duplicate is success, not an error).
+ */
+export class InboxController {
+  static async receive(req: Request, res: Response): Promise<Response> {
+    if (!isInboxEnabled()) {
+      return res.status(503).json({ status: 'error', message: 'Reverse inbox is disabled.' });
+    }
+
+    const rawBody = (req as Request & { rawBody?: Buffer }).rawBody;
+    if (!Buffer.isBuffer(rawBody)) {
+      // The route-scoped raw parser did not run — a wiring bug, loud rather than a silent 401.
+      logger.error('Reverse inbox: req.rawBody is not a Buffer; raw-body parser not mounted.');
+      return res.status(500).json({ status: 'error', message: 'Raw body unavailable.' });
+    }
+
+    const outcome = await verifyAndWrite(rawBody, req.headers, readVerifierConfig());
+
+    if (outcome.result === 'REJECTED') {
+      if (outcome.reason === 'MALFORMED_BODY') {
+        // Authenticated (the verifier only returns MALFORMED_BODY after headers/window/key pass on
+        // a parse failure) but unusable — dead-letter with the raw payload and ACK.
+        await InboxController.deadLetterRaw(rawBody, outcome.reason);
+        return res.status(202).json({ status: 'accepted' });
+      }
+      logger.warn(`Reverse inbox rejected an instruction: ${outcome.reason}`);
+      return res.status(401).json({ status: 'error', message: 'Signature verification failed.' });
+    }
+
+    // ACCEPTED or DUPLICATE both ACK 202: the instruction is durably recorded (or already was).
+    return res.status(202).json({ status: 'accepted' });
+  }
+
+  private static async deadLetterRaw(rawBody: Buffer, reason: string): Promise<void> {
+    let payload: Record<string, unknown>;
+    try {
+      payload = JSON.parse(rawBody.toString('utf8')) as Record<string, unknown>;
+    } catch {
+      payload = { raw: rawBody.toString('utf8').slice(0, 4000) };
+    }
+    await InboxDeadLetter.create({
+      event_id: typeof payload.event_id === 'string' ? payload.event_id : null,
+      event_type: typeof payload.event_type === 'string' ? payload.event_type : null,
+      idempotency_key: typeof payload.idempotency_key === 'string' ? payload.idempotency_key : null,
+      reason,
+      detail: 'Authenticated but structurally invalid reverse instruction.',
+      payload,
+      inbox_event_id: null,
+    } as never);
+  }
+}

--- a/server/src/modules/Inbox/inbox.routes.ts
+++ b/server/src/modules/Inbox/inbox.routes.ts
@@ -1,0 +1,26 @@
+import express, { NextFunction, Request, Response, Router } from 'express';
+import { InboxController } from './inbox.controller';
+
+/**
+ * The reverse-inbox route. Authenticated by HMAC (ADR-0025 §5), NOT by the staff JWT `verify`
+ * middleware — the caller is the co-deployed Accounting service, not a logged-in user.
+ *
+ * A ROUTE-SCOPED raw body parser captures the exact bytes for HMAC verification, isolated from the
+ * global `bodyParser.json()`: the signature covers the raw body, so a re-serialisation by the JSON
+ * parser would change the hash. This router is mounted BEFORE the global json() in the route table,
+ * so these bytes reach the verifier untouched.
+ */
+const router = Router();
+
+const rawJson = express.raw({ type: 'application/json', limit: '5mb' });
+
+function stashRawBody(req: Request, _res: Response, next: NextFunction): void {
+  if (Buffer.isBuffer(req.body)) {
+    (req as Request & { rawBody?: Buffer }).rawBody = req.body;
+  }
+  next();
+}
+
+router.post('/events', rawJson, stashRawBody, InboxController.receive);
+
+export default router;

--- a/server/src/modules/Inbox/processor.ts
+++ b/server/src/modules/Inbox/processor.ts
@@ -1,0 +1,138 @@
+import { Op, Transaction } from 'sequelize';
+import { sequelizeConnection } from '../../database/config/data-source';
+import { InboxEvent } from '../../database/models/inboxEvent';
+import { InboxDeadLetter } from '../../database/models/inboxDeadLetter';
+import { logger } from '../../core/helpers/logger';
+import { applyInstruction } from './applier';
+
+/**
+ * Drains the inbox: reads PENDING rows and applies each exactly once (ADR-0018, ADR-0025 §6b).
+ *
+ * Per row, in ONE transaction: apply the effect AND flip the row to its terminal status AND advance
+ * the sequence high-water mark — all-or-nothing, so a crash never leaves an applied effect whose
+ * dedup/status did not commit.
+ *
+ * An authenticated instruction that CANNOT be applied dead-letters (full payload + reason) and the
+ * row is marked FAILED — never dropped, never retried forever. Recording a failure must not itself
+ * throw (the dead-letter table has no unique key), or the failure would vanish as we record it.
+ */
+
+const BATCH_SIZE = Number(process.env.EMR_INBOX_BATCH_SIZE || 50);
+
+export interface DrainResult {
+  readonly claimed: number;
+  readonly applied: number;
+  readonly discarded: number;
+  readonly unhandled: number;
+  readonly failed: number;
+}
+
+async function deadLetter(
+  row: InboxEvent,
+  reason: string,
+  detail: string,
+  transaction: Transaction
+): Promise<void> {
+  await InboxDeadLetter.create(
+    {
+      event_id: row.event_id,
+      event_type: row.event_type,
+      idempotency_key: row.idempotency_key,
+      reason,
+      detail: detail.slice(0, 2000),
+      payload: row.payload,
+      inbox_event_id: row.id,
+    } as never,
+    { transaction }
+  );
+  await InboxEvent.update(
+    { status: 'FAILED', processed_at: new Date(), attempts: row.attempts + 1 },
+    { where: { id: row.id }, transaction }
+  );
+  logger.error(
+    `Reverse inbox dead-lettered ${row.event_type} ${row.event_id}: ${reason} - ${detail}`
+  );
+}
+
+export type ProcessOutcome = 'APPLIED' | 'DISCARDED_STALE' | 'UNHANDLED' | 'FAILED' | 'SKIPPED';
+
+/** Processes one PENDING row by id. Public so a scheduler and tests can drive a drain directly. */
+export async function processOne(inboxEventId: number): Promise<ProcessOutcome> {
+  return sequelizeConnection.transaction(async transaction => {
+    const row = await InboxEvent.findByPk(inboxEventId, {
+      lock: transaction.LOCK.UPDATE,
+      transaction,
+    });
+
+    if (row === null) {
+      logger.warn(`Reverse inbox row ${inboxEventId} vanished before it could be drained.`);
+      return 'SKIPPED';
+    }
+
+    // Terminal already: a redelivered drain for a row we finished. Nothing to redo.
+    if (row.status !== 'PENDING') {
+      return 'SKIPPED';
+    }
+
+    try {
+      const result = await applyInstruction(
+        row.event_type,
+        row.aggregate_id,
+        Number(row.sequence),
+        row.payload,
+        transaction
+      );
+
+      // A stale overwrite is recorded PROCESSED (recognised-and-discarded), not FAILED: losing a
+      // race is correct behaviour, not an error.
+      const status = result.outcome === 'UNHANDLED' ? 'UNHANDLED' : 'PROCESSED';
+
+      if (result.outcome === 'DISCARDED_STALE') {
+        logger.info(
+          `Reverse inbox discarded ${row.event_type} ${row.event_id} as stale (sequence ${row.sequence}).`
+        );
+      }
+
+      await InboxEvent.update(
+        { status, processed_at: new Date(), attempts: row.attempts + 1 },
+        { where: { id: row.id }, transaction }
+      );
+      return result.outcome;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      await deadLetter(row, 'HANDLER_ERROR', message, transaction);
+      return 'FAILED';
+    }
+  });
+}
+
+/** One drain pass over the PENDING backlog. */
+export async function drainInbox(batchSize = BATCH_SIZE): Promise<DrainResult> {
+  const pending = await InboxEvent.findAll({
+    where: { status: 'PENDING' },
+    order: [['id', 'ASC']],
+    limit: batchSize,
+  });
+
+  const result = { claimed: pending.length, applied: 0, discarded: 0, unhandled: 0, failed: 0 };
+
+  for (const row of pending) {
+    const outcome = await processOne(row.id);
+    if (outcome === 'APPLIED') result.applied += 1;
+    else if (outcome === 'DISCARDED_STALE') result.discarded += 1;
+    else if (outcome === 'UNHANDLED') result.unhandled += 1;
+    else if (outcome === 'FAILED') result.failed += 1;
+  }
+
+  return result;
+}
+
+/** Rows still PENDING past a threshold — the sweeper's re-derivation query. */
+export async function findStranded(staleAfterSeconds = 30, limit = 500): Promise<InboxEvent[]> {
+  const cutoff = new Date(Date.now() - staleAfterSeconds * 1000);
+  return InboxEvent.findAll({
+    where: { status: 'PENDING', createdAt: { [Op.lt]: cutoff } },
+    order: [['id', 'ASC']],
+    limit,
+  });
+}

--- a/server/src/modules/Inbox/verifier.test.ts
+++ b/server/src/modules/Inbox/verifier.test.ts
@@ -1,0 +1,131 @@
+import { signEvent } from '../Outbox/signer';
+import { verifyReverseSignature, VerifierConfig } from './verifier';
+
+/**
+ * Pure tests for the reverse-signature verifier — no DB. The verifier and the outbox signer are two
+ * implementations of ADR-0025 §5; signing with one and verifying with the other proves they agree
+ * on the base. (Accounting's own signer is a third implementation; this proves OUR two agree.)
+ */
+
+const KEY = { keyId: 'acct-2026-07', secret: 'reverse-secret' };
+const TENANT = 'st_vincent';
+
+const config = (): VerifierConfig => ({
+  keys: [{ keyId: KEY.keyId, secret: KEY.secret }],
+  expectedTenantKey: TENANT,
+  maxSkewSeconds: 300,
+});
+
+function envelope(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const sentAt = '2026-07-23T10:00:05.000Z';
+  return {
+    event_id: '019f8e38-38d4-70f0-abd6-e350d8427f5c',
+    event_type: 'payment.settled',
+    event_version: 1,
+    tenant_key: TENANT,
+    occurred_at: '2026-07-23T10:00:00.000Z',
+    sent_at: sentAt,
+    aggregate: { type: 'reverse_encounter', id: 'visit:8891' },
+    sequence: 1,
+    idempotency_key: 'settled:cl-1',
+    body: { external_line_ref: { type: 'drug', id: '42' }, encounter_id: 'visit:8891' },
+    ...overrides,
+  };
+}
+
+describe('verifyReverseSignature', () => {
+  it('accepts a signature the outbox signer produced (the two agree on §5)', () => {
+    const env = envelope();
+    const signed = signEvent(env, KEY);
+    const now = new Date(String(env.sent_at));
+
+    const result = verifyReverseSignature(
+      Buffer.from(signed.rawBody, 'utf8'),
+      signed.headers,
+      config(),
+      now
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.keyId).toBe(KEY.keyId);
+  });
+
+  it('rejects a tampered body (SIGNATURE_MISMATCH)', () => {
+    const env = envelope();
+    const signed = signEvent(env, KEY);
+    const now = new Date(String(env.sent_at));
+
+    const tampered = Buffer.from(signed.rawBody.replace('"42"', '"99"'), 'utf8');
+    const result = verifyReverseSignature(tampered, signed.headers, config(), now);
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('SIGNATURE_MISMATCH');
+  });
+
+  it('rejects a wrong key id (UNKNOWN_KEY_ID)', () => {
+    const env = envelope();
+    const signed = signEvent(env, { keyId: 'someone-else', secret: KEY.secret });
+    const now = new Date(String(env.sent_at));
+
+    const result = verifyReverseSignature(
+      Buffer.from(signed.rawBody, 'utf8'),
+      signed.headers,
+      config(),
+      now
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('UNKNOWN_KEY_ID');
+  });
+
+  it('rejects an expired timestamp AND a future one (both window edges)', () => {
+    const env = envelope();
+    const signed = signEvent(env, KEY);
+    const sentAt = new Date(String(env.sent_at));
+
+    const expired = new Date(sentAt.getTime() + 6 * 60 * 1000);
+    const future = new Date(sentAt.getTime() - 6 * 60 * 1000);
+
+    expect(
+      verifyReverseSignature(Buffer.from(signed.rawBody, 'utf8'), signed.headers, config(), expired)
+        .reason
+    ).toBe('TIMESTAMP_OUTSIDE_WINDOW');
+    expect(
+      verifyReverseSignature(Buffer.from(signed.rawBody, 'utf8'), signed.headers, config(), future)
+        .reason
+    ).toBe('TIMESTAMP_OUTSIDE_WINDOW');
+  });
+
+  it('rejects a mismatched tenant_key AFTER the signature holds', () => {
+    // Signed correctly, but with a tenant_key this deployment does not expect.
+    const env = envelope({ tenant_key: 'some_other_hospital' });
+    const signed = signEvent(env, KEY);
+    const now = new Date(String(env.sent_at));
+
+    const result = verifyReverseSignature(
+      Buffer.from(signed.rawBody, 'utf8'),
+      signed.headers,
+      config(),
+      now
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('TENANT_KEY_MISMATCH');
+  });
+
+  it('rejects missing signature headers (MALFORMED_HEADERS)', () => {
+    const env = envelope();
+    const signed = signEvent(env, KEY);
+    const now = new Date(String(env.sent_at));
+
+    const result = verifyReverseSignature(
+      Buffer.from(signed.rawBody, 'utf8'),
+      { 'x-ehmrs-key-id': KEY.keyId },
+      config(),
+      now
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('MALFORMED_HEADERS');
+  });
+});

--- a/server/src/modules/Inbox/verifier.ts
+++ b/server/src/modules/Inbox/verifier.ts
@@ -1,0 +1,148 @@
+import { createHash, createHmac, timingSafeEqual } from 'crypto';
+
+/**
+ * Verifies a reverse (Accounting → EMR) instruction's HMAC — the mirror of the outbox `signEvent`,
+ * and byte-for-byte identical to Accounting's own inbound verifier (ADR-0025 §5).
+ *
+ * Base: `event_id + "\n" + tenant_key + "\n" + sent_at + "\n" + sha256(raw_body)`, hashed over the
+ * bytes AS RECEIVED. Hashing the raw body rather than a re-serialisation sidesteps JSON key-order
+ * entirely — two serialisers ordering keys differently would otherwise disagree for identical
+ * events.
+ *
+ * Order is cheap-rejections-first (headers, window, key lookup) so junk costs little, with the HMAC
+ * computed only once a request is otherwise plausible. `tenant_key` is verified and REJECTED on
+ * mismatch, AFTER the signature holds — on an unsigned request, checking it first would leak
+ * whether a guessed tenant_key was right. It is sender authentication of one provisioned pair, not
+ * tenant discrimination: ADR-0023/ADR-0026 leave one hospital, one database.
+ *
+ * A SEPARATE key from the EMR's OUTBOUND direction (ADR-0025 Q5.5): the key Accounting signs with
+ * is the key we verify with here, and it is not the one we sign our own outbox with.
+ */
+
+export type VerificationFailure =
+  | 'MALFORMED_HEADERS'
+  | 'MALFORMED_BODY'
+  | 'TIMESTAMP_OUTSIDE_WINDOW'
+  | 'UNKNOWN_KEY_ID'
+  | 'SIGNATURE_MISMATCH'
+  | 'TENANT_KEY_MISMATCH';
+
+export interface VerificationKey {
+  readonly keyId: string;
+  readonly secret: string;
+}
+
+export interface VerifierConfig {
+  readonly keys: readonly VerificationKey[];
+  readonly expectedTenantKey: string;
+  readonly maxSkewSeconds: number;
+}
+
+/**
+ * A FLAT result rather than a discriminated union: this repo compiles with `strict` off, and
+ * without `strictNullChecks` TypeScript will not narrow a union on its `ok` discriminant — a caller
+ * reading `result.reason` after `if (!result.ok)` would not see the field. The flat shape sidesteps
+ * that entirely. On failure `reason` is set and the rest undefined; on success the reverse.
+ */
+export interface VerificationResult {
+  readonly ok: boolean;
+  readonly reason?: VerificationFailure;
+  readonly keyId?: string;
+  readonly parsedBody?: Record<string, unknown>;
+}
+
+const SIGNATURE_PATTERN = /^v1=([0-9a-f]+)$/;
+
+function header(headers: Record<string, unknown>, name: string): string | undefined {
+  const value = headers[name] ?? headers[name.toLowerCase()];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function envelopeIdentity(parsed: unknown): { eventId: string; tenantKey: string } | undefined {
+  if (typeof parsed !== 'object' || parsed === null) {
+    return undefined;
+  }
+  const record = parsed as Record<string, unknown>;
+  const eventId = record.event_id;
+  const tenantKey = record.tenant_key;
+  if (typeof eventId !== 'string' || typeof tenantKey !== 'string') {
+    return undefined;
+  }
+  return { eventId, tenantKey };
+}
+
+function hexEqual(a: string, b: string): boolean {
+  // Compare as fixed-width buffers: timingSafeEqual throws on a length mismatch, and the throw
+  // would itself be the timing signal we are trying not to emit.
+  if (a.length !== b.length) {
+    return false;
+  }
+  return timingSafeEqual(Buffer.from(a, 'hex'), Buffer.from(b, 'hex'));
+}
+
+export function verifyReverseSignature(
+  rawBody: Buffer,
+  headers: Record<string, unknown>,
+  config: VerifierConfig,
+  now: Date = new Date()
+): VerificationResult {
+  const signatureHeader = header(headers, 'x-ehmrs-signature');
+  const keyIdHeader = header(headers, 'x-ehmrs-key-id');
+  const timestampHeader = header(headers, 'x-ehmrs-timestamp');
+
+  if (!signatureHeader || !keyIdHeader || !timestampHeader) {
+    return { ok: false, reason: 'MALFORMED_HEADERS' };
+  }
+
+  const signatureMatch = SIGNATURE_PATTERN.exec(signatureHeader);
+  if (signatureMatch === null) {
+    return { ok: false, reason: 'MALFORMED_HEADERS' };
+  }
+  const presentedSignature = signatureMatch[1];
+
+  const sentAtMs = Date.parse(timestampHeader);
+  if (Number.isNaN(sentAtMs)) {
+    return { ok: false, reason: 'MALFORMED_HEADERS' };
+  }
+
+  // Both edges matter: a replay attacker controls the timestamp they claim, so a far-future
+  // sent_at would otherwise buy an arbitrarily long replay window.
+  if (Math.abs(now.getTime() - sentAtMs) > config.maxSkewSeconds * 1000) {
+    return { ok: false, reason: 'TIMESTAMP_OUTSIDE_WINDOW' };
+  }
+
+  const key = config.keys.find(candidate => candidate.keyId === keyIdHeader);
+  if (key === undefined) {
+    return { ok: false, reason: 'UNKNOWN_KEY_ID' };
+  }
+
+  let parsedBody: unknown;
+  try {
+    parsedBody = JSON.parse(rawBody.toString('utf8'));
+  } catch {
+    return { ok: false, reason: 'MALFORMED_BODY' };
+  }
+
+  const identity = envelopeIdentity(parsedBody);
+  if (identity === undefined) {
+    return { ok: false, reason: 'MALFORMED_BODY' };
+  }
+
+  const bodyHash = createHash('sha256')
+    .update(rawBody)
+    .digest('hex');
+  const base = [identity.eventId, identity.tenantKey, timestampHeader, bodyHash].join('\n');
+  const expected = createHmac('sha256', key.secret)
+    .update(base)
+    .digest('hex');
+
+  if (!hexEqual(presentedSignature, expected)) {
+    return { ok: false, reason: 'SIGNATURE_MISMATCH' };
+  }
+
+  if (identity.tenantKey !== config.expectedTenantKey) {
+    return { ok: false, reason: 'TENANT_KEY_MISMATCH' };
+  }
+
+  return { ok: true, keyId: key.keyId, parsedBody: parsedBody as Record<string, unknown> };
+}


### PR DESCRIPTION
## Issue #4 Phase B2 — the reverse Accounting → EMR inbox

The receiving half of the reverse channel (ADR-0018, ADR-0023, ADR-0025 §6b). Accounting's `payment.settled` / `payment.refunded` instructions are verified, durably recorded, and applied to the EMR's own prescribed rows. This is the **mirror of the A1 outbox** on the receiving side, and it builds on `svsh_branch` (which already carries A1).

> **Separate system boundary.** Accounting never writes the EMR's `payment_status` directly — that would be ADR-0011's lethal shortcut in mirror image. It sends a signed instruction; **the EMR applies it to its own row**.

### What landed

- **`verifier.ts`** — HMAC verify over the **raw** request body (§5): constant-time compare, both window edges, key-id lookup, `tenant_key` rejected on mismatch. A **separate inbound key** (Q5.5). A round-trip test proves it accepts exactly what the A1 outbox `signEvent` produces.
- **Models + migration** — `Inbox_Events` (durability boundary, unique `idempotency_key`), `Inbox_Dead_Letters` (non-unique key so recording a failure can't throw), `Inbox_Sequences` (per-encounter high-water for stale-overwrite discard). Lands additive; applies to the test DB alongside A1's outbox migration.
- **Route + controller (B2.1)** — `POST /api/integration/accounting/events`, HMAC-authenticated (not the staff JWT). A **route-scoped raw parser mounted *before* the global `bodyParser.json()`** so the signature covers the exact bytes. Verify → write `Inbox_Events` → commit → **ACK 202**. Forged → **401, nothing written**; duplicate → 202 no new row; malformed-but-authenticated → DLQ + 202.
- **`applier.ts` (B2.2)** — routes off the closed five-type set (`additional_item` included), flips `payment_status` **only** (decision 9 — no dispense side-effect; a refund reverts to `Pending` and **never un-dispenses**, Q6b.4), sequence-guarded overwrite. Existence is checked by a read, not the UPDATE's affected-row count — MySQL reports 0 affected on a no-op update, which would otherwise wrongly dead-letter a valid resend.
- **`gate.ts` (B2.3)** — reads the recorded `payment_status` and **fails safe**: HOLDS on `Pending`/missing/stale, releases only on `Paid`/`Cleared`/`Permitted`. Read-only, no synchronous EMR write.
- **`processor.ts` (B2.4)** — drains PENDING, applies each in one transaction; any throw → `Inbox_Dead_Letters` with **full payload + structured reason**, row FAILED, drain continues.

### Note on types

Result shapes are **flat interfaces, not discriminated unions**: this repo compiles with `strict` off, and without `strictNullChecks` TypeScript won't narrow a union on its `ok` discriminant — a caller reading `result.reason` after `if (!result.ok)` wouldn't see the field. The flat shape sidesteps that.

### Testing (against real MySQL)

```
verifier.test.ts        6 passed   (signature, both window edges, tenant_key, round-trip vs signer)
applier.test.ts         8 passed   (status flip, idempotent-by-sequence, never un-dispense, gate)
inbox-pipeline.test.ts  5 passed   (verify→write→drain→apply, forged→nothing, dedup, DLQ)

All issue-#4 module suites (Inbox + A1 Outbox): 11 suites, 94/94 green.
tsc --noEmit: 0 errors.  eslint: clean.
```

The pre-existing HTTP-endpoint suites (staff, pharmacy, …) fail on the clean `svsh_branch` base too — **confirmed by stashing these changes and re-running** — so they are not a B2 regression. (They need seed/auth context the test DB lacks; noted in the issue plan.)

### Config

New env, off by default (endpoint 503s until enabled): `EMR_INBOX_ENABLED`, and the reverse-direction key `EMR_INBOUND_KEY_ID` / `EMR_INBOUND_SECRET` (separate from the outbound key, Q5.5). Like A1's keys, these are env-held pending ADR-0023's local secret-storage slice.

### Not in this PR

The corresponding `[ACCT]` side (B1 — reverse outbox + drainer) is on the `ehmrs_accounting` repo (its own PR). Phase C/D (inventory reconciliation, bidirectional tracer) are separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
