### PR TITLE
feat(outbox): emit payer on charge.captured — issue #114 (ADR-0028)

### DIFF
--- a/server/src/modules/Outbox/contract-handshake.test.ts
+++ b/server/src/modules/Outbox/contract-handshake.test.ts
@@ -84,6 +84,83 @@ function buildAndSign() {
   return signEvent(row.payload, SHARED_KEY);
 }
 
+/**
+ * Mirrors Accounting's `chargeCapturedPayerSchema` (event-contract.ts, ADR-0028), reconstructed
+ * from the contract — not imported, for the same independence reason as the verifier above.
+ * `payer_type` is one of the three literals; each id, when present, is a non-empty string; and no
+ * key outside the four the schema allows may appear.
+ */
+const ALLOWED_PAYER_KEYS = new Set(['payer_type', 'scheme_id', 'hmo_id', 'retainership_id']);
+const PAYER_TYPES = new Set(['cash', 'scheme_hmo', 'retainership']);
+
+function payerPassesAccountingGuard(payer: unknown): boolean {
+  if (typeof payer !== 'object' || payer === null) return false;
+  const p = payer as Record<string, unknown>;
+  if (!PAYER_TYPES.has(p.payer_type as string)) return false;
+  for (const key of Object.keys(p)) {
+    if (!ALLOWED_PAYER_KEYS.has(key)) return false;
+    if (key === 'payer_type') continue;
+    if (typeof p[key] !== 'string' || (p[key] as string).length === 0) return false;
+  }
+  return true;
+}
+
+function buildPayerBody(payer: {
+  payer_type: 'cash' | 'scheme_hmo' | 'retainership';
+  scheme_id?: string;
+  hmo_id?: string;
+  retainership_id?: string;
+}) {
+  const row = buildChargeCapturedEvent(
+    {
+      type: 'drug',
+      id: 1,
+      patient_id: 100,
+      visit_id: 8891,
+      amount: '2500.00',
+      quantity: 2,
+      service_date: '2026-07-22',
+      payer,
+    },
+    { tenantKey: TENANT_KEY, sequence: 42 }
+  );
+  return (row.payload.body as Record<string, unknown>).payer;
+}
+
+describe('charge.captured payer passes Accounting chargeCapturedPayerSchema (#114)', () => {
+  it('accepts a scheme_hmo payer with scheme_id and hmo_id', () => {
+    expect(
+      payerPassesAccountingGuard(
+        buildPayerBody({ payer_type: 'scheme_hmo', scheme_id: '3', hmo_id: '7' })
+      )
+    ).toBe(true);
+  });
+
+  it('accepts a retainership payer keyed by the company hmo id', () => {
+    expect(
+      payerPassesAccountingGuard(
+        buildPayerBody({ payer_type: 'retainership', retainership_id: '42' })
+      )
+    ).toBe(true);
+  });
+
+  it('a cash line carries no payer, which the schema accepts as absent', () => {
+    const row = buildChargeCapturedEvent(
+      {
+        type: 'drug',
+        id: 1,
+        patient_id: 100,
+        visit_id: 8891,
+        amount: '2500.00',
+        quantity: 2,
+        service_date: '2026-07-22',
+      },
+      { tenantKey: TENANT_KEY, sequence: 42 }
+    );
+    expect('payer' in (row.payload.body as Record<string, unknown>)).toBe(false);
+  });
+});
+
 describe('EMR outbox ↔ Accounting inbox handshake', () => {
   it('a signed event is ACCEPTED by the verifier', () => {
     const signed = buildAndSign();

--- a/server/src/modules/Outbox/emit-for-rows.test.ts
+++ b/server/src/modules/Outbox/emit-for-rows.test.ts
@@ -2,7 +2,15 @@ import '../../core/config/env';
 import { sequelizeConnection } from '../../database/config/data-source';
 import { OutboxEvent } from '../../database/models/outboxEvent';
 import { OutboxSequence } from '../../database/models/outboxSequence';
+import { Insurance } from '../../database/models/insurance';
+import { HMO } from '../../database/models/hmo';
+import { PatientInsurance } from '../../database/models/patientInsurance';
+import { Patient } from '../../database/models/patient';
 import { emitChargeCapturedForRows, normalisePrice } from './outbox-writer';
+
+afterAll(async () => {
+  await sequelizeConnection.close();
+});
 
 describe('normalisePrice', () => {
   it('leaves a DECIMAL string untouched', () => {
@@ -44,9 +52,8 @@ const consumableRow = (id: number) => ({
 describe('emitChargeCapturedForRows (A1.2a wiring)', () => {
   const originalFlag = process.env.EMR_OUTBOX_ENABLED;
 
-  afterAll(async () => {
+  afterAll(() => {
     process.env.EMR_OUTBOX_ENABLED = originalFlag;
-    await sequelizeConnection.close();
   });
   beforeEach(async () => {
     await OutboxEvent.destroy({ where: {}, truncate: true, force: true });
@@ -120,5 +127,199 @@ describe('emitChargeCapturedForRows (A1.2a wiring)', () => {
 
     expect(threw).toBe(true);
     expect(await OutboxEvent.count()).toBe(0);
+  });
+
+  it('omits the payer for a cash line (no patient_insurance_id)', async () => {
+    process.env.EMR_OUTBOX_ENABLED = 'true';
+    const t = await sequelizeConnection.transaction();
+    await emitChargeCapturedForRows('drug', [drugRow(60)], '2026-07-22', t);
+    await t.commit();
+
+    const [row] = await OutboxEvent.findAll();
+    const body = row.payload.body as Record<string, unknown>;
+    expect('payer' in body).toBe(false);
+  });
+});
+
+/**
+ * The payer-derivation path (#114) — reads the line's own patient_insurance_id against real MySQL
+ * and attaches the resolved ID-only payer. Seeds an Insurance + PatientInsurance so the resolver
+ * has a row to classify.
+ */
+describe('emitChargeCapturedForRows — payer derivation (#114)', () => {
+  const originalFlag = process.env.EMR_OUTBOX_ENABLED;
+  let patientId: number;
+  let schemeInsuranceId: number;
+  let retainerInsuranceId: number;
+  let schemeHmoId: number;
+  let retainerCompanyHmoId: number;
+  let schemePatientInsuranceId: number;
+  let retainerPatientInsuranceId: number;
+
+  beforeAll(async () => {
+    // The FK chain (Patient_Insurances → Patients / Insurances / HMOs) is real in the test schema,
+    // so the parent rows must exist. Seed the minimum: a patient, two insurances, an HMO under each.
+    const patient = await Patient.create({
+      firstname: 'Test',
+      lastname: 'Payer',
+      gender: 'Male',
+      phone: '08000000000',
+      address: 'N/A',
+      country: 'Nigeria',
+      state: 'Lagos',
+      lga: 'Ikeja',
+      date_of_birth: new Date('1990-01-01'),
+      has_insurance: true,
+    } as never);
+    patientId = patient.id;
+
+    const scheme = await Insurance.create({ name: 'NHIS' } as never);
+    const retainer = await Insurance.create({ name: 'Retainership' } as never);
+    schemeInsuranceId = scheme.id;
+    retainerInsuranceId = retainer.id;
+
+    const schemeHmo = await HMO.create({
+      name: 'Scheme HMO',
+      insurance_id: schemeInsuranceId,
+    } as never);
+    const retainerCompany = await HMO.create({
+      name: 'Retainer Co',
+      insurance_id: retainerInsuranceId,
+    } as never);
+    schemeHmoId = schemeHmo.id;
+    retainerCompanyHmoId = retainerCompany.id;
+
+    const schemePi = await PatientInsurance.create({
+      patient_id: patientId,
+      insurance_id: schemeInsuranceId,
+      hmo_id: schemeHmoId,
+    } as never);
+    const retainerPi = await PatientInsurance.create({
+      patient_id: patientId,
+      insurance_id: retainerInsuranceId,
+      hmo_id: retainerCompanyHmoId,
+    } as never);
+    schemePatientInsuranceId = schemePi.id;
+    retainerPatientInsuranceId = retainerPi.id;
+  });
+
+  afterAll(async () => {
+    process.env.EMR_OUTBOX_ENABLED = originalFlag;
+    await PatientInsurance.destroy({
+      where: { id: [schemePatientInsuranceId, retainerPatientInsuranceId] },
+      force: true,
+    });
+    await HMO.destroy({ where: { id: [schemeHmoId, retainerCompanyHmoId] }, force: true });
+    await Insurance.destroy({
+      where: { id: [schemeInsuranceId, retainerInsuranceId] },
+      force: true,
+    });
+    await Patient.destroy({ where: { id: patientId }, force: true });
+  });
+
+  beforeEach(async () => {
+    process.env.EMR_OUTBOX_ENABLED = 'true';
+    await OutboxEvent.destroy({ where: {}, truncate: true, force: true });
+    await OutboxSequence.destroy({ where: {}, truncate: true, force: true });
+  });
+
+  const insuredDrugRow = (id: number, patient_insurance_id: number, drug_type = 'NHIS') => ({
+    id,
+    patient_id: patientId,
+    visit_id: 8891,
+    total_price: '2500.00',
+    quantity_prescribed: 1,
+    patient_insurance_id,
+    drug_type,
+  });
+
+  it('emits a scheme_hmo payer for an NHIS line — ids only, no name/enrollee_code', async () => {
+    const t = await sequelizeConnection.transaction();
+    await emitChargeCapturedForRows(
+      'drug',
+      [insuredDrugRow(70, schemePatientInsuranceId)],
+      '2026-07-22',
+      t
+    );
+    await t.commit();
+
+    const [row] = await OutboxEvent.findAll();
+    const body = row.payload.body as Record<string, unknown>;
+    expect(body.payer).toEqual({
+      payer_type: 'scheme_hmo',
+      scheme_id: String(schemeInsuranceId),
+      hmo_id: String(schemeHmoId),
+    });
+    // No demographic value leaked into the payload anywhere.
+    const serialised = JSON.stringify(row.payload);
+    expect(serialised).not.toContain('NHIS');
+    expect(serialised).not.toContain('enrollee');
+  });
+
+  it('emits a retainership payer keyed by the company hmo id', async () => {
+    const t = await sequelizeConnection.transaction();
+    await emitChargeCapturedForRows(
+      'drug',
+      [insuredDrugRow(71, retainerPatientInsuranceId)],
+      '2026-07-22',
+      t
+    );
+    await t.commit();
+
+    const [row] = await OutboxEvent.findAll();
+    expect((row.payload.body as Record<string, unknown>).payer).toEqual({
+      payer_type: 'retainership',
+      retainership_id: String(retainerCompanyHmoId),
+    });
+  });
+
+  it('omits the payer when the line is Cash despite an insurance on file', async () => {
+    const t = await sequelizeConnection.transaction();
+    await emitChargeCapturedForRows(
+      'drug',
+      [insuredDrugRow(72, schemePatientInsuranceId, 'Cash')],
+      '2026-07-22',
+      t
+    );
+    await t.commit();
+
+    const [row] = await OutboxEvent.findAll();
+    expect('payer' in (row.payload.body as Record<string, unknown>)).toBe(false);
+  });
+
+  it('falls back to cash (no payer) when patient_insurance_id resolves to no row', async () => {
+    const t = await sequelizeConnection.transaction();
+    await emitChargeCapturedForRows('drug', [insuredDrugRow(73, 9_999_999)], '2026-07-22', t);
+    await t.commit();
+
+    const [row] = await OutboxEvent.findAll();
+    expect('payer' in (row.payload.body as Record<string, unknown>)).toBe(false);
+  });
+
+  it('resolves once for a bulk sharing one patient_insurance_id (all rows get the payer)', async () => {
+    const findOneSpy = jest.spyOn(PatientInsurance, 'findOne');
+    const t = await sequelizeConnection.transaction();
+    await emitChargeCapturedForRows(
+      'drug',
+      [
+        insuredDrugRow(74, schemePatientInsuranceId),
+        insuredDrugRow(75, schemePatientInsuranceId),
+        insuredDrugRow(76, schemePatientInsuranceId),
+      ],
+      '2026-07-22',
+      t
+    );
+    await t.commit();
+
+    const rows = await OutboxEvent.findAll();
+    expect(rows).toHaveLength(3);
+    for (const row of rows) {
+      expect((row.payload.body as Record<string, unknown>).payer).toMatchObject({
+        payer_type: 'scheme_hmo',
+      });
+    }
+    // One lookup for three rows sharing the id — the per-resolver cache.
+    expect(findOneSpy).toHaveBeenCalledTimes(1);
+    findOneSpy.mockRestore();
   });
 });

--- a/server/src/modules/Outbox/event-builder.test.ts
+++ b/server/src/modules/Outbox/event-builder.test.ts
@@ -136,4 +136,49 @@ describe('buildChargeCapturedEvent', () => {
     expect(body.patient_id).toBe('100');
     expect(body.visit_id).toBe('8891');
   });
+
+  it('omits the payer entirely when the line carries none (cash — ADR-0028)', () => {
+    const row = buildChargeCapturedEvent(baseLine, context);
+    const body = row.payload.body as Record<string, unknown>;
+    expect('payer' in body).toBe(false);
+  });
+
+  it('emits a scheme_hmo payer with scheme_id and hmo_id as strings, ids only', () => {
+    const row = buildChargeCapturedEvent(
+      { ...baseLine, payer: { payer_type: 'scheme_hmo', scheme_id: '3', hmo_id: '7' } },
+      context
+    );
+    const payer = (row.payload.body as Record<string, unknown>).payer;
+    expect(payer).toEqual({ payer_type: 'scheme_hmo', scheme_id: '3', hmo_id: '7' });
+  });
+
+  it('emits a retainership payer carrying the company hmo id as retainership_id', () => {
+    const row = buildChargeCapturedEvent(
+      { ...baseLine, payer: { payer_type: 'retainership', retainership_id: '42' } },
+      context
+    );
+    expect((row.payload.body as Record<string, unknown>).payer).toEqual({
+      payer_type: 'retainership',
+      retainership_id: '42',
+    });
+  });
+
+  it('drops absent id fields rather than emitting a stray key', () => {
+    const row = buildChargeCapturedEvent(
+      { ...baseLine, payer: { payer_type: 'scheme_hmo', scheme_id: '3', hmo_id: '7' } },
+      context
+    );
+    const payer = (row.payload.body as Record<string, unknown>).payer as Record<string, unknown>;
+    expect('retainership_id' in payer).toBe(false);
+  });
+
+  it('stringifies a numeric payer id (numbers coming off a Sequelize row)', () => {
+    const row = buildChargeCapturedEvent(
+      // @ts-expect-error the wire type is string; a raw numeric id must still serialise to a string
+      { ...baseLine, payer: { payer_type: 'retainership', retainership_id: 42 } },
+      context
+    );
+    const payer = (row.payload.body as Record<string, unknown>).payer as Record<string, unknown>;
+    expect(payer.retainership_id).toBe('42');
+  });
 });

--- a/server/src/modules/Outbox/event-builder.ts
+++ b/server/src/modules/Outbox/event-builder.ts
@@ -66,6 +66,23 @@ export function visitAggregateId(visitId: number | string): string {
   return `visit:${visitId}`;
 }
 
+/**
+ * The payer reference carried on `charge.captured` (ADR-0028). Additive, optional, ID-only: it
+ * tells Accounting which payer the patient was under at prescription time so it can resolve the
+ * split. No demographics (ADR-0016) — scheme/hmo ids only, never a name or membership number. No
+ * money. A missing payer means cash; the receiver defaults an absent field to `patient-liable`.
+ *
+ * The EMR has no `retainership_id`: retainership is an Insurance (scheme) type and the retainer
+ * companies are HMO rows under it, so a retainership line carries the company `hmo_id` as
+ * `retainership_id` (owned by Accounting #138 on the receiving end).
+ */
+export interface ChargeCapturedPayer {
+  readonly payer_type: 'cash' | 'scheme_hmo' | 'retainership';
+  readonly scheme_id?: string;
+  readonly hmo_id?: string;
+  readonly retainership_id?: string;
+}
+
 export interface PrescribedLineInput {
   readonly type: PrescribedLineType;
   readonly id: number | string;
@@ -77,6 +94,8 @@ export interface PrescribedLineInput {
   readonly service_date: string;
   readonly department?: string;
   readonly service_line?: string;
+  /** Payer at prescription time (ADR-0028). Omitted for cash lines; ID references only. */
+  readonly payer?: ChargeCapturedPayer;
 }
 
 export interface BuildContext {
@@ -104,6 +123,25 @@ function assertNoDemographics(body: Record<string, unknown>): void {
       );
     }
   }
+}
+
+/**
+ * Serialises a payer for the wire: `payer_type` plus only the id fields that are present, each as a
+ * string (ids are INTEGER autoincrement in the EMR). Absent ids are dropped rather than emitted as
+ * null/undefined, so a scheme_hmo payer never carries a stray `retainership_id` and vice versa.
+ */
+function buildPayer(payer: ChargeCapturedPayer): Record<string, unknown> {
+  const wire: Record<string, unknown> = { payer_type: payer.payer_type };
+  if (payer.scheme_id !== undefined) {
+    wire.scheme_id = String(payer.scheme_id);
+  }
+  if (payer.hmo_id !== undefined) {
+    wire.hmo_id = String(payer.hmo_id);
+  }
+  if (payer.retainership_id !== undefined) {
+    wire.retainership_id = String(payer.retainership_id);
+  }
+  return wire;
 }
 
 /**
@@ -167,6 +205,9 @@ export function buildChargeCapturedEvent(
   }
   if (line.service_line !== undefined) {
     body.service_line = line.service_line;
+  }
+  if (line.payer !== undefined) {
+    body.payer = buildPayer(line.payer);
   }
 
   assertNoDemographics(body);

--- a/server/src/modules/Outbox/outbox-writer.ts
+++ b/server/src/modules/Outbox/outbox-writer.ts
@@ -2,7 +2,12 @@ import { QueryTypes, Transaction } from 'sequelize';
 import { sequelizeConnection } from '../../database/config/data-source';
 import { OutboxEvent } from '../../database/models/outboxEvent';
 import { buildChargeCapturedEvent, visitAggregateId, PrescribedLineInput } from './event-builder';
-import { PRICE_FIELD_BY_TYPE, PrescribedLineType } from './prescribed-line-types';
+import {
+  COVERAGE_TYPE_FIELD_BY_TYPE,
+  PRICE_FIELD_BY_TYPE,
+  PrescribedLineType,
+} from './prescribed-line-types';
+import { PayerResolver } from './payer-derivation';
 
 /**
  * Writes charge.captured events to the outbox INSIDE a clinical write transaction (ADR-0018).
@@ -147,8 +152,11 @@ export async function emitChargeCapturedForRows(
   }
 
   const priceField = PRICE_FIELD_BY_TYPE[type];
+  const coverageField = COVERAGE_TYPE_FIELD_BY_TYPE[type];
+  const payerResolver = new PayerResolver(transaction);
   for (const raw of rows) {
     const row = asPrescribedRecord(raw);
+    const payer = await payerResolver.resolve(row.patient_insurance_id, row[coverageField]);
     const input: PrescribedLineInput = {
       type,
       id: Number(row.id),
@@ -157,6 +165,7 @@ export async function emitChargeCapturedForRows(
       amount: normalisePrice(row[priceField]),
       quantity: Number(row.quantity_prescribed ?? row.quantity ?? 1),
       service_date: serviceDate,
+      payer,
     };
     await emitChargeCaptured(input, transaction);
   }

--- a/server/src/modules/Outbox/payer-classification.test.ts
+++ b/server/src/modules/Outbox/payer-classification.test.ts
@@ -1,0 +1,28 @@
+import { classifyPayer } from './payer-classification';
+
+describe('classifyPayer', () => {
+  it('returns undefined (cash) when there are no coverage facts', () => {
+    expect(classifyPayer(null)).toBeUndefined();
+  });
+
+  it('maps a Retainership insurance to a retainership payer keyed by the company hmo id', () => {
+    const payer = classifyPayer({ insurance_id: 9, hmo_id: 42, insuranceName: 'Retainership' });
+    expect(payer).toEqual({ payer_type: 'retainership', retainership_id: '42' });
+  });
+
+  it.each(['NHIS', 'FHSS', 'PHIS'])('maps insurance %s to a scheme_hmo payer', name => {
+    const payer = classifyPayer({ insurance_id: 3, hmo_id: 7, insuranceName: name });
+    expect(payer).toEqual({ payer_type: 'scheme_hmo', scheme_id: '3', hmo_id: '7' });
+  });
+
+  it('carries no retainership_id on a scheme_hmo payer', () => {
+    const payer = classifyPayer({ insurance_id: 3, hmo_id: 7, insuranceName: 'NHIS' });
+    expect(payer && 'retainership_id' in payer).toBe(false);
+  });
+
+  it('carries no scheme_id / hmo_id on a retainership payer', () => {
+    const payer = classifyPayer({ insurance_id: 9, hmo_id: 42, insuranceName: 'Retainership' });
+    expect(payer && 'scheme_id' in payer).toBe(false);
+    expect(payer && 'hmo_id' in payer).toBe(false);
+  });
+});

--- a/server/src/modules/Outbox/payer-classification.ts
+++ b/server/src/modules/Outbox/payer-classification.ts
@@ -1,0 +1,44 @@
+import { ChargeCapturedPayer } from './event-builder';
+
+/**
+ * Pure payer classification for `charge.captured` (ADR-0028) — no DB, no Sequelize models, so it
+ * stays unit-testable in isolation. The `PayerResolver` (payer-derivation.ts) loads the row and
+ * feeds these facts in.
+ *
+ * Classification (insurance `name` is the discriminator, matching the EMR's existing coverage
+ * semantics in `EXCLUDED_INSURANCE` / `getDrugType`):
+ *  - no coverage facts                          → cash (payer omitted)
+ *  - insurance name is `Retainership`           → retainership, retainership_id = hmo_id
+ *  - any other insurance (NHIS / FHSS / PHIS …) → scheme_hmo, scheme_id + hmo_id
+ *
+ * The EMR has no `retainership_id`: retainer companies are HMO rows under a `Retainership`
+ * insurance, so the company `hmo_id` identifies the agreement on the wire (Accounting #138 seeds
+ * `RetainershipAgreement.retainership_id` to those same ids).
+ */
+
+export interface CoverageFacts {
+  readonly insurance_id: number;
+  readonly hmo_id: number;
+  readonly insuranceName: string | null | undefined;
+}
+
+const RETAINERSHIP_INSURANCE_NAME = 'Retainership';
+
+export function classifyPayer(facts: CoverageFacts | null): ChargeCapturedPayer | undefined {
+  if (!facts) {
+    return undefined;
+  }
+
+  if (facts.insuranceName === RETAINERSHIP_INSURANCE_NAME) {
+    return {
+      payer_type: 'retainership',
+      retainership_id: String(facts.hmo_id),
+    };
+  }
+
+  return {
+    payer_type: 'scheme_hmo',
+    scheme_id: String(facts.insurance_id),
+    hmo_id: String(facts.hmo_id),
+  };
+}

--- a/server/src/modules/Outbox/payer-derivation.ts
+++ b/server/src/modules/Outbox/payer-derivation.ts
@@ -1,0 +1,72 @@
+import { Transaction } from 'sequelize';
+import { PatientInsurance } from '../../database/models/patientInsurance';
+import { Insurance } from '../../database/models/insurance';
+import { ChargeCapturedPayer } from './event-builder';
+import { classifyPayer } from './payer-classification';
+
+/**
+ * Derives the `payer` a prescribed line was raised under (ADR-0028), from the line's own
+ * `patient_insurance_id` — NOT the patient's default insurance, because a patient may hold more
+ * than one and the line records which applied. The classification itself is pure
+ * (`payer-classification.ts`); this loads the row and feeds it in.
+ *
+ * A `patient_insurance_id` that resolves to no row falls back to cash rather than throwing: a stale
+ * FK must never roll back a clinical write, and unverified coverage is never granted (owner
+ * decision). Cash is the safe default the receiver already assumes for an absent payer.
+ */
+
+/** True when the row's own coverage marker says it is a cash line, regardless of any insurance. */
+function isCashLine(patientInsuranceId: unknown, lineType: unknown): boolean {
+  if (patientInsuranceId === null || patientInsuranceId === undefined) {
+    return true;
+  }
+  return typeof lineType === 'string' && lineType.toLowerCase() === 'cash';
+}
+
+/**
+ * Loads the `PatientInsurance` for a line and classifies it, caching per id so a bulk prescribe
+ * that shares one `patient_insurance_id` across many rows issues a single lookup. Runs on the
+ * caller's transaction — never opens its own.
+ */
+export class PayerResolver {
+  private readonly cache = new Map<number, ChargeCapturedPayer | undefined>();
+
+  constructor(private readonly transaction: Transaction) {}
+
+  async resolve(
+    patientInsuranceId: unknown,
+    lineType: unknown
+  ): Promise<ChargeCapturedPayer | undefined> {
+    if (isCashLine(patientInsuranceId, lineType)) {
+      return undefined;
+    }
+
+    const id = Number(patientInsuranceId);
+    if (!Number.isInteger(id)) {
+      return undefined;
+    }
+
+    if (this.cache.has(id)) {
+      return this.cache.get(id);
+    }
+
+    const insurance = await PatientInsurance.findOne({
+      where: { id },
+      attributes: ['id', 'insurance_id', 'hmo_id'],
+      include: [{ model: Insurance, attributes: ['name'] }],
+      transaction: this.transaction,
+    });
+
+    const payer = classifyPayer(
+      insurance
+        ? {
+            insurance_id: insurance.insurance_id,
+            hmo_id: insurance.hmo_id,
+            insuranceName: insurance.insurance?.name,
+          }
+        : null
+    );
+    this.cache.set(id, payer);
+    return payer;
+  }
+}

--- a/server/src/modules/Outbox/prescribed-line-types.ts
+++ b/server/src/modules/Outbox/prescribed-line-types.ts
@@ -36,6 +36,20 @@ export const PRICE_FIELD_BY_TYPE: Record<PrescribedLineType, string> = {
   investigation: 'price',
 };
 
+/**
+ * Which column carries the coverage marker (`Cash`/`NHIS`/…) per type — the field that says a line
+ * was raised as cash regardless of any insurance on file. Co-located with the price field for the
+ * same reason: the column name is not uniform (`drug_type` for drug and additional_item, a
+ * `*_type` variant for the rest), and a per-call-site literal is how it drifts.
+ */
+export const COVERAGE_TYPE_FIELD_BY_TYPE: Record<PrescribedLineType, string> = {
+  drug: 'drug_type',
+  additional_item: 'drug_type',
+  test: 'test_type',
+  service: 'service_type',
+  investigation: 'investigation_type',
+};
+
 export function isPrescribedLineType(value: unknown): value is PrescribedLineType {
   return typeof value === 'string' && PRESCRIBED_LINE_TYPES.some(type => type === value);
 }

--- a/tasks/114-emr-payer-on-charge-captured.md
+++ b/tasks/114-emr-payer-on-charge-captured.md
@@ -1,0 +1,155 @@
+# Task Plan — Issue #114: [EMR] Emit the `payer` field on `charge.captured` (ADR-0028)
+
+**Repo:** `ehmrs` (Express + Sequelize + MySQL + TypeScript). Branch
+`114-emr-payer-on-charge-captured`, cut from `svsh_branch`. **This repo's conventions govern** —
+`ehmrs_accounting`'s CONVENTIONS.md does not apply here, and none of its tooling (`Money` type,
+schema guard, strict lint floor) exists.
+
+**Governing ADRs** (all live in `ehmrs_accounting`, where the contract is defined):
+**0028** (payer rides on `charge.captured` as a versioned additive field — the spec for this issue),
+**0025** (frozen v1 event contract; additive-field evolution rule), **0016** (identity by reference —
+IDs only, no demographics), **0015** (payer model: Scheme→HMO, retainership as corporate AR),
+**0001** (EMR owns the coverage fact at prescription time).
+
+**The receiver is already live** (`ehmrs_accounting` PR #113). Build against it, not a reimplementation:
+- `apps/api/src/modules/integration/event-contract.ts` — `chargeCapturedPayerSchema`, the Zod guard
+  the emitted `payer` must pass.
+- `apps/api/src/modules/coverage/coverage-resolver.ts` — how each `payer_type` is interpreted.
+
+---
+
+## Reality check — verified in this repo before planning (2026-07-25)
+
+Every claim below was checked against the code on `114-emr-payer-on-charge-captured`, not assumed.
+
+- **The A1 outbox is landed** (commit `d0f9f4c`, PR #5). `buildChargeCapturedEvent`
+  (`event-builder.ts`) assembles the wire body; `emitChargeCapturedForRows` (`outbox-writer.ts`) is
+  the single call every prescribe site makes. This issue extends both — no new emit path.
+- **All five prescribed models carry `patient_insurance_id`** (`prescribedDrug`, `prescribedTest`,
+  `prescribedInvestigation`, `prescribedService`, `prescribedAdditionalItem`) — confirmed one
+  declaration each. So the payer is derivable from the row itself.
+- **`getPatientInsuranceQuery({ patient_id })`** (`Insurance/insurance.repository.ts`) already
+  returns `insurance_id`, `hmo_id`, `id`, and includes `Insurance` with its `name`. It is the
+  lookup the payer derivation needs — no new query surface. **But it keys by `patient_id`, not by
+  `patient_insurance_id`**, and returns *a* patient-insurance (the first match), not necessarily the
+  one a line was prescribed under. The row carries the exact `patient_insurance_id`; the derivation
+  must resolve *that* row (see decision 3).
+- **The insurance `name` values in use are `NHIS`, `FHSS`, `PHIS`, `Retainership`** (from
+  `EXCLUDED_INSURANCE`, `getDrugType`, and the `PharmacyDrugType`/`AcceptedDrugType` enums).
+  `Retainership` is an `Insurance` (scheme) type; retainer companies are `HMO` rows under it. There
+  is **no `retainership_id`** in the EMR (see decision 2).
+- **16 emit call sites across 8 files** (`Admission`, `Surgery`, `Visit`, `Orders/{Pharmacy,
+  Laboratory,Radiology,Service}`). **None changes** — the payer rides on the row, derived inside
+  `emitChargeCapturedForRows`. This is the property that keeps the blast radius to two files
+  (`event-builder.ts`, `outbox-writer.ts`) plus tests.
+- **The existing outbox tests hit real MySQL** (`emit-for-rows.test.ts`, `contract-handshake.test.ts`)
+  with plain-object rows standing in for Sequelize instances; `event-builder.test.ts` is pure. New
+  tests extend these in the same style.
+
+---
+
+## Design decisions settled before implementation
+
+1. **The payload builder stays the only enforcement point.** The `payer` object is attached in
+   `buildChargeCapturedEvent`, after `service_line`, before `assertNoDemographics` — so the
+   demographic guard also walks the payer's keys. IDs are `String(...)`-ed exactly as `patient_id`
+   and `external_line_ref.id` already are. The field is emitted **only when it has content**; never
+   `payer: undefined`, never an empty object.
+
+2. **Retainership maps to the retainer-company `hmo_id` (SETTLED, owned by Accounting #138).** The
+   EMR has no `retainership_id`; a retainership line is a `PatientInsurance` whose `insurance.name`
+   is `Retainership`, carrying `insurance_id` + a company `hmo_id`. Accounting reads only
+   `retainership_id` for `payer_type: "retainership"`. **The wire `retainership_id` = the EMR
+   company `hmo_id`.** This session emits `retainership_id = String(hmo_id)`; the matching
+   obligation (Accounting seeding `RetainershipAgreement.retainership_id` to those ids) is issue
+   #138's, not ours. Do not fabricate a separate id.
+
+3. **Payer derivation reads the line's own `patient_insurance_id`, not a patient-wide lookup.** A
+   patient may hold more than one insurance; the line records which one it was prescribed under.
+   The derivation:
+   - `patient_insurance_id` is null/absent, **or** the row's `*_type` is `Cash` → `payer_type:
+     "cash"`, omit the id fields.
+   - otherwise load the `PatientInsurance` by that id (with its `Insurance`), then:
+     - `insurance.name === 'Retainership'` → `payer_type: "retainership"`,
+       `retainership_id = String(hmo_id)`.
+     - any other insurance → `payer_type: "scheme_hmo"`, `scheme_id = String(insurance_id)`,
+       `hmo_id = String(hmo_id)`.
+   A `patient_insurance_id` that resolves to no row is a data bug: **fall back to cash** (never grant
+   unverified coverage) rather than throwing and rolling back a clinical write.
+
+4. **The lookup runs on the caller's transaction and is cached per `patient_insurance_id`.** A bulk
+   prescribe creates many rows that share one `patient_insurance_id`; derive once per distinct id,
+   not once per row. Never open a new transaction — pass the caller's `{ transaction }`.
+
+5. **No new flag, no `event_version` bump.** The change rides behind the existing
+   `EMR_OUTBOX_ENABLED`. Omitting `payer` stays valid (a cash line omits it); old and new senders
+   coexist. `event_version` stays 1 — this is an additive field (ADR-0028), not a new version.
+
+6. **ID-only, no demographics (ADR-0016).** Send `insurance_id` / `hmo_id` only — never the
+   insurance `name`, `enrollee_code`, `plan`, or `organization`. `assertNoDemographics` catches a
+   demographic *key* but not a demographic *value* smuggled into an id field; a test asserts the
+   payload carries no name/enrollee_code anywhere.
+
+---
+
+## Tasks (build order)
+
+- [ ] **114.1 — Builder: accept and emit `payer`.** In `event-builder.ts`, add
+      `ChargeCapturedPayer` (the contract type) and an optional `payer?: ChargeCapturedPayer` on
+      `PrescribedLineInput`; attach it to `body` when present, before `assertNoDemographics`. Unit
+      tests in `event-builder.test.ts`: scheme_hmo / retainership / cash-omitted shapes; ids are
+      strings; no demographic key or value leaks.
+- [x] **114.2 — Payer classification + resolver.** `payer-classification.ts` holds the pure
+      `classifyPayer(CoverageFacts)` (model-free, unit-tested in isolation); `payer-derivation.ts`
+      holds `PayerResolver`, which loads the line's own `patient_insurance_id` on the caller's
+      transaction and caches per id. (Retainership → retainership; NHIS/FHSS/PHIS → scheme_hmo;
+      null/Cash → undefined; unresolved id → undefined/cash.)
+- [x] **114.3 — Wire it into `emitChargeCapturedForRows`.** Resolves the payer per row and passes
+      it to the builder; **no call site changed** (16 sites across 8 files untouched). Integration
+      tests (real MySQL): scheme_hmo, retainership, cash-despite-insurance, unresolved-fallback-to-
+      cash, one-lookup-per-shared-id.
+- [x] **114.4 — Payer passes Accounting's guard.** `contract-handshake.test.ts` reconstructs
+      `chargeCapturedPayerSchema` (independently, per the file's existing convention) and asserts
+      each built payer passes it; a cash line carries no payer. Real cross-repo resolution is gated
+      on #138.
+- [x] **114.5 — Suites green.** All 9 Outbox suites pass (96 tests); typecheck clean. Pre-existing
+      full-suite failures (Staff/Insurance/Visit/… — 26 suites) reproduce identically on the clean
+      baseline with my changes stashed, so they are unrelated cross-suite DB-state failures, not
+      regressions.
+
+---
+
+## Downstream dependency — Accounting #138
+
+Accounting's coverage tables currently hold placeholder slugs (`sch_nhis_standard`,
+`hmo_zenith_care`, `ret_oilserv_production`), not the EMR's real ids. A correctly-emitted `payer`
+therefore still resolves as cash outside test fixtures until **#138** repopulates those tables with
+real EMR ids. #114 is not blocked from landing; its real-world resolution is gated on #138. Do not
+mistake a passing slug-fixture test for a production-ready split.
+
+---
+
+## Review
+
+**Summary.** Adds the optional, ID-only `payer` to `charge.captured` (ADR-0028). Blast radius: two
+production files (`event-builder.ts`, `outbox-writer.ts`), a small `prescribed-line-types.ts`
+addition (`COVERAGE_TYPE_FIELD_BY_TYPE`), and two new modules (`payer-classification.ts`,
+`payer-derivation.ts`). No prescribe call site changed — the payer rides on the prescribed row and
+is derived inside the existing emit helper.
+
+**Key decisions.**
+- Payer derived from the line's own `patient_insurance_id`, not the patient default — correct for
+  multi-insurance patients (owner-confirmed).
+- Unresolved `patient_insurance_id` falls back to cash, never throws — a stale FK must not roll back
+  a clinical write, and unverified coverage is never granted (owner-confirmed).
+- Retainership → `retainership_id = String(hmo_id)` (the retainer company's EMR HMO id), the settled
+  cross-repo mapping; Accounting #138 keys its agreements to match.
+- Pure classification split from the DB resolver so it unit-tests without loading Sequelize.
+
+**Testing evidence.** Outbox module: 9 suites / 96 tests green — unit (builder + classification +
+handshake) and integration against real MySQL (emit-for-rows payer paths). `tsc --noEmit`: 0 errors.
+
+**Limitations / follow-ups.** Real-deployment resolution is gated on **Accounting #138** (coverage
+tables still hold placeholder slugs, not real EMR ids); until it lands an insured charge safely
+falls back to cash. The full EMR suite has 26 pre-existing failing suites from cross-suite shared-DB
+state — unrelated to this change and confirmed present on the clean baseline.


### PR DESCRIPTION
Closes #114 (EMR side). Follow-up to the A1 outbox (#5) and Accounting PR #113.

## What & why

The A1 outbox emitted `charge.captured` with **no payer**, so Accounting defaulted every insured charge to cash. This adds the optional, ID-only `payer` field (ADR-0028) to the `charge.captured` body, derived from the prescribed line's own coverage.

The field is **additive and optional** — no `event_version` bump, a missing payer stays valid and means cash. Old and new senders coexist; no deployment lockstep.

## How

The payer rides on the prescribed row, so **no prescribe call site changed** (16 sites across 8 files untouched). Blast radius is two production files plus two new small modules:

- `event-builder.ts` — `ChargeCapturedPayer` type + `buildPayer` (stringifies ids, drops absent id fields), attached before `assertNoDemographics`.
- `payer-classification.ts` — pure `classifyPayer(CoverageFacts)`, unit-tested in isolation (no DB).
- `payer-derivation.ts` — `PayerResolver` loads the line's own `patient_insurance_id` on the caller's transaction, cached per id (one lookup per bulk prescribe).
- `outbox-writer.ts` / `prescribed-line-types.ts` — resolves the payer per row using the per-type coverage column.

### Payer mapping (mirrors the EMR's existing coverage semantics)
- no `patient_insurance_id`, or a `Cash` line → **cash** (payer omitted)
- insurance name `Retainership` → **retainership**, `retainership_id = String(hmo_id)` (the retainer company's EMR HMO id)
- any other insurance (NHIS / FHSS / PHIS) → **scheme_hmo**, `scheme_id` + `hmo_id`
- a `patient_insurance_id` that resolves to no row → **falls back to cash** (never rolls back a clinical write; never grants unverified coverage)

**ID-only (ADR-0016):** only `insurance_id` / `hmo_id` cross the wire — never the insurance name, enrollee code, plan, or organization. A test asserts no demographic value leaks into the payload.

## Testing
- Outbox module: **9 suites / 96 tests green** (unit: builder + classification + handshake; integration against real MySQL: every payer path). Verified stable across repeated runs.
- `tsc --noEmit`: 0 errors.
- The broader EMR suite has pre-existing cross-suite shared-DB failures (Staff/Insurance/Visit/…) that reproduce identically on the clean baseline with these changes stashed — unrelated to this PR.

## ⚠️ Real-deployment resolution is gated on Accounting #138
Accounting's coverage tables (`TariffRule`, `RetainershipAgreement`) currently hold **placeholder slugs**, not the EMR's real ids. A correctly-emitted `payer` therefore still resolves as cash outside test fixtures until **#138** repopulates those tables with real EMR ids (retainership agreements keyed by the EMR company `hmo_id`). This PR is not blocked; its production payoff depends on #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)