### PR TITLE
[EMR] Emit emergency on encounter.opened + settlement/discharge gate-check (#137)

### DIFF
--- a/server/src/modules/Admission/admission.service.ts
+++ b/server/src/modules/Admission/admission.service.ts
@@ -52,6 +52,8 @@ import { getVisitPrescriptions } from '../Consultation/consultation.repository';
 import { CreateDeliveryInfo, CreatePostNatal } from '../Antenatal/types/antenatal.types';
 import { getPatientInsuranceQuery } from '../Insurance/insurance.repository';
 import { DischargeStatus, VisitCategory } from '../../database/enums';
+import { checkGate, gateHoldMessage, isHold } from '../Outbox/gate-check';
+import { visitAggregateId } from '../Outbox/event-builder';
 
 export class AdmissionService {
   /**
@@ -339,6 +341,17 @@ export class AdmissionService {
     staffId: number
   ): Promise<Discharge> {
     const admission = await getOneAdmission({ id: admissionId });
+
+    // The authoritative payment gate (issue #137). Fails closed: an outstanding balance, an
+    // unverifiable state, or an unreachable Accounting all HOLD the discharge.
+    const gate = await checkGate({
+      kind: 'discharge',
+      encounter_id: visitAggregateId(admission.visit_id),
+    });
+    if (isHold(gate)) {
+      throw new BadException('FORBIDDEN', StatusCodes.FORBIDDEN, gateHoldMessage(gate));
+    }
+
     const data = {
       ...body,
       admission_id: admission.id,

--- a/server/src/modules/Inbox/gate.ts
+++ b/server/src/modules/Inbox/gate.ts
@@ -18,6 +18,13 @@ import { isPrescribedLineType, PrescribedLineType } from '../Outbox/prescribed-l
  * There is deliberately NO synchronous counter→EMR write to "freshen" the status on demand: that
  * would make Accounting's commit wait on a cross-engine HTTP write and let a slow EMR block the
  * cashier from taking money. The gate reads only what has already been durably recorded here.
+ *
+ * DELIBERATELY UNWIRED (issue #137). No release path calls this. The authoritative gate at the
+ * dispense and discharge sites is the synchronous, fail-closed `checkGate` in
+ * `Outbox/gate-check.ts`, which folds in emergency-bypass, override, and the recorded-paid check
+ * server-side. Composing the two would only create a gate that can DISAGREE with the authoritative
+ * one: the local `payment_status` projection is precisely the stale data the remote call exists to
+ * see past. Left in place for the reverse-inbox applier's use; do not wire it into a release path.
  */
 
 const MODEL_BY_TYPE: Record<PrescribedLineType, ModelStatic<Model>> = {

--- a/server/src/modules/Outbox/encounter-opened.test.ts
+++ b/server/src/modules/Outbox/encounter-opened.test.ts
@@ -1,0 +1,85 @@
+import {
+  buildEncounterOpenedEvent,
+  encounterOpenedIdempotencyKey,
+  buildChargeCapturedEvent,
+} from './event-builder';
+
+/**
+ * `encounter.opened` must satisfy the Accounting receiver's guard
+ * (`encounterOpenedBodySchema` = `{ emergency: z.boolean().optional() }`) and its LATCH semantics:
+ * the handler acts only on `emergency === true` and has no path that clears the flag.
+ */
+
+const context = {
+  tenantKey: 'lagoon_general',
+  sequence: 7,
+  occurredAt: new Date('2026-07-26T10:00:00.000Z'),
+  sentAt: new Date('2026-07-26T10:00:01.000Z'),
+};
+
+describe('encounterOpenedIdempotencyKey', () => {
+  it('is deterministic on the visit, so a redelivery dedupes at the inbox', () => {
+    expect(encounterOpenedIdempotencyKey(8891)).toBe('encounter-opened:8891');
+    expect(encounterOpenedIdempotencyKey(8891)).toBe(encounterOpenedIdempotencyKey('8891'));
+  });
+});
+
+describe('buildEncounterOpenedEvent', () => {
+  it('emits { emergency: true } for an emergency visit', () => {
+    const row = buildEncounterOpenedEvent({ visit_id: 8891, emergency: true }, context);
+
+    expect(row.event_type).toBe('encounter.opened');
+    expect(row.payload.body).toEqual({ emergency: true });
+  });
+
+  it('emits an empty body for a routine visit — never an explicit false', () => {
+    const row = buildEncounterOpenedEvent({ visit_id: 8891, emergency: false }, context);
+
+    // A `false` is indistinguishable from absent at the receiver; emitting one would imply an
+    // encounter can be corrected back to routine, which the latch makes impossible.
+    expect(row.payload.body).toEqual({});
+    expect(Object.keys(row.payload.body as Record<string, unknown>)).not.toContain('emergency');
+  });
+
+  it('carries the flag and nothing else — no patient, no category, no demographics (ADR-0016)', () => {
+    const row = buildEncounterOpenedEvent({ visit_id: 8891, emergency: true }, context);
+    const serialised = JSON.stringify(row.payload.body);
+
+    expect(Object.keys(row.payload.body as Record<string, unknown>)).toEqual(['emergency']);
+    for (const leak of ['patient', 'name', 'category', 'Emergency', 'department', 'hospital']) {
+      expect(serialised).not.toContain(leak);
+    }
+  });
+
+  it('reuses the v1 envelope shape charge.captured already produces', () => {
+    const opened = buildEncounterOpenedEvent({ visit_id: 8891, emergency: true }, context);
+    const charge = buildChargeCapturedEvent(
+      {
+        type: 'drug',
+        id: 1,
+        patient_id: 100,
+        visit_id: 8891,
+        amount: '2500.00',
+        quantity: 2,
+        service_date: '2026-07-26',
+      },
+      context
+    );
+
+    expect(Object.keys(opened.payload).sort()).toEqual(Object.keys(charge.payload).sort());
+    expect(opened.payload.aggregate).toEqual(charge.payload.aggregate);
+    expect(opened.payload.event_version).toBe(1);
+    expect(opened.payload.tenant_key).toBe('lagoon_general');
+    expect(opened.payload.event_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+    );
+  });
+
+  it('anchors on the visit aggregate so the anchor matches charge.captured', () => {
+    const row = buildEncounterOpenedEvent({ visit_id: 8891, emergency: true }, context);
+
+    expect(row.aggregate_type).toBe('encounter');
+    expect(row.aggregate_id).toBe('visit:8891');
+    expect(row.idempotency_key).toBe('encounter-opened:8891');
+  });
+});

--- a/server/src/modules/Outbox/event-builder.ts
+++ b/server/src/modules/Outbox/event-builder.ts
@@ -158,6 +158,14 @@ export function chargeIdempotencyKey(type: PrescribedLineType, id: number | stri
   return `charge:${type}:${id}`;
 }
 
+/**
+ * `encounter-opened:{visit_id}` — one open per visit, deterministic on domain identity rather than
+ * on the send attempt (ADR-0025 §3), so a redelivery dedupes at the inbox.
+ */
+export function encounterOpenedIdempotencyKey(visitId: number | string): string {
+  return `encounter-opened:${visitId}`;
+}
+
 export interface OutboxEventRow {
   readonly aggregate_type: string;
   readonly aggregate_id: string;
@@ -232,6 +240,57 @@ export function buildChargeCapturedEvent(
     event_type: 'charge.captured',
     event_version: context.eventVersion ?? 1,
     idempotency_key: chargeIdempotencyKey(line.type, line.id),
+    payload,
+  };
+}
+
+export interface EncounterOpenedInput {
+  readonly visit_id: number | string;
+  readonly emergency: boolean;
+}
+
+/**
+ * Builds an `encounter.opened` outbox row. The body carries ONE optional boolean and nothing else
+ * (ADR-0016): no patient id, no category string, no department.
+ *
+ * The flag is emitted only when true. Accounting LATCHES on `emergency === true` and has no code
+ * path that clears it, so a `false` is indistinguishable from an absent field at the receiver —
+ * emitting one would falsely imply an encounter can be corrected back to routine.
+ */
+export function buildEncounterOpenedEvent(
+  input: EncounterOpenedInput,
+  context: BuildContext
+): OutboxEventRow {
+  const encounterId = visitAggregateId(input.visit_id);
+  const occurredAt = context.occurredAt ?? new Date();
+  const sentAt = context.sentAt ?? new Date();
+  const idempotencyKey = encounterOpenedIdempotencyKey(input.visit_id);
+  const eventVersion = context.eventVersion ?? 1;
+
+  const body: Record<string, unknown> = input.emergency ? { emergency: true } : {};
+
+  assertNoDemographics(body);
+
+  const payload: Record<string, unknown> = {
+    event_id: uuidV7(context.now),
+    event_type: 'encounter.opened',
+    event_version: eventVersion,
+    tenant_key: context.tenantKey,
+    occurred_at: occurredAt.toISOString(),
+    sent_at: sentAt.toISOString(),
+    aggregate: { type: 'encounter', id: encounterId },
+    sequence: Number(context.sequence),
+    idempotency_key: idempotencyKey,
+    body,
+  };
+
+  return {
+    aggregate_type: 'encounter',
+    aggregate_id: encounterId,
+    sequence: context.sequence,
+    event_type: 'encounter.opened',
+    event_version: eventVersion,
+    idempotency_key: idempotencyKey,
     payload,
   };
 }

--- a/server/src/modules/Outbox/gate-check.test.ts
+++ b/server/src/modules/Outbox/gate-check.test.ts
@@ -1,0 +1,290 @@
+import { createHash, createHmac } from 'crypto';
+import {
+  CANNOT_VERIFY_MESSAGE,
+  GatePoster,
+  NOT_PAID_MESSAGE,
+  checkGate,
+  gateHoldMessage,
+  isHold,
+} from './gate-check';
+
+/**
+ * The gate is FAIL-CLOSED: every path that is not a definite `allow` must hold, and
+ * `cannot-verify` must stay distinct from `not-paid`.
+ *
+ * The signature test reconstructs the Accounting verifier's base from ADR-0025 §5 INDEPENDENTLY
+ * (as `contract-handshake.test.ts` does) rather than importing it — the verifier lives in another
+ * repo, and a test that called it would agree by construction and could drift alongside it. The
+ * sharp edge it guards: the receiver reads `event_id` and `tenant_key` OUT OF THE JSON BODY, so a
+ * request carrying them only in headers is rejected before the gate is ever consulted.
+ */
+
+const KEY_ID = 'emr-2026-07';
+const SECRET = 'shared-secret-abc';
+const TENANT_KEY = 'lagoon_general';
+const GATE_URL = 'http://127.0.0.1:4000/integration/emr/gate-check';
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  process.env.EMR_GATE_CHECK_ENABLED = 'true';
+  process.env.EMR_ACCOUNTING_GATE_CHECK_URL = GATE_URL;
+  process.env.EMR_OUTBOUND_KEY_ID = KEY_ID;
+  process.env.EMR_OUTBOUND_SECRET = SECRET;
+  process.env.EMR_TENANT_KEY = TENANT_KEY;
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+/** A poster that replies with a fixed status/body and captures what it was sent. */
+function posterReplying(
+  status: number,
+  body: string
+): { poster: GatePoster; sent: { url?: string; body?: string; headers?: Record<string, string> } } {
+  const sent: { url?: string; body?: string; headers?: Record<string, string> } = {};
+  const poster: GatePoster = async (url, requestBody, headers) => {
+    sent.url = url;
+    sent.body = requestBody;
+    sent.headers = headers;
+    return { status, body };
+  };
+  return { poster, sent };
+}
+
+const allow = (reason: string) => JSON.stringify({ kind: 'allow', reason });
+const blocked = (reason: string) => JSON.stringify({ kind: 'blocked', reason });
+
+describe('checkGate — allow paths', () => {
+  it.each(['recorded-paid', 'emergency-bypass', 'override'])('allows on %s', async reason => {
+    const { poster } = posterReplying(200, allow(reason));
+
+    const result = await checkGate(
+      {
+        kind: 'settlement',
+        encounter_id: 'visit:8891',
+        external_line_ref: { type: 'drug', id: '1' },
+      },
+      poster
+    );
+
+    expect(result).toEqual({ allowed: true, reason });
+  });
+});
+
+describe('checkGate — fails closed', () => {
+  it('holds on not-paid, and reports it as not-paid', async () => {
+    const { poster } = posterReplying(200, blocked('not-paid'));
+
+    const result = await checkGate({ kind: 'discharge', encounter_id: 'visit:8891' }, poster);
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe('not-paid');
+  });
+
+  it('holds on cannot-verify WITHOUT conflating it with not-paid', async () => {
+    const { poster } = posterReplying(200, blocked('cannot-verify'));
+
+    const result = await checkGate({ kind: 'discharge', encounter_id: 'visit:8891' }, poster);
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe('cannot-verify');
+    expect(result.reason).not.toBe('not-paid');
+  });
+
+  it('holds as cannot-verify when the gate is unreachable', async () => {
+    const poster: GatePoster = async () => {
+      throw new Error('ECONNREFUSED');
+    };
+
+    const result = await checkGate({ kind: 'discharge', encounter_id: 'visit:8891' }, poster);
+
+    expect(result).toMatchObject({ allowed: false, reason: 'cannot-verify' });
+  });
+
+  it('holds as cannot-verify when the request times out', async () => {
+    const poster: GatePoster = async () => {
+      throw Object.assign(new Error('The operation was aborted due to timeout'), {
+        name: 'TimeoutError',
+      });
+    };
+
+    const result = await checkGate({ kind: 'discharge', encounter_id: 'visit:8891' }, poster);
+
+    expect(result).toMatchObject({ allowed: false, reason: 'cannot-verify' });
+  });
+
+  it.each([401, 404, 500, 503])('holds as cannot-verify on HTTP %s', async status => {
+    const { poster } = posterReplying(status, '');
+
+    const result = await checkGate({ kind: 'discharge', encounter_id: 'visit:8891' }, poster);
+
+    expect(result).toMatchObject({ allowed: false, reason: 'cannot-verify' });
+  });
+
+  it('holds as cannot-verify on an unparseable body', async () => {
+    const { poster } = posterReplying(200, '<html>gateway error</html>');
+
+    const result = await checkGate({ kind: 'discharge', encounter_id: 'visit:8891' }, poster);
+
+    expect(result).toMatchObject({ allowed: false, reason: 'cannot-verify' });
+  });
+
+  it('does NOT honour an allow-reason it does not recognise', async () => {
+    // An old EMR must not silently release on a reason a newer receiver invented.
+    const { poster } = posterReplying(200, allow('some-future-reason'));
+
+    const result = await checkGate({ kind: 'discharge', encounter_id: 'visit:8891' }, poster);
+
+    expect(result).toMatchObject({ allowed: false, reason: 'cannot-verify' });
+  });
+
+  it('does not read a garbled decision as paid', async () => {
+    const { poster } = posterReplying(200, JSON.stringify({ ok: true }));
+
+    const result = await checkGate({ kind: 'discharge', encounter_id: 'visit:8891' }, poster);
+
+    expect(result).toMatchObject({ allowed: false, reason: 'cannot-verify' });
+  });
+});
+
+describe('checkGate — flag', () => {
+  it('allows without calling when the gate is disabled', async () => {
+    process.env.EMR_GATE_CHECK_ENABLED = 'false';
+    let called = false;
+    const poster: GatePoster = async () => {
+      called = true;
+      return { status: 200, body: blocked('not-paid') };
+    };
+
+    const result = await checkGate({ kind: 'discharge', encounter_id: 'visit:8891' }, poster);
+
+    expect(result).toEqual({ allowed: true, reason: 'gate-disabled' });
+    expect(called).toBe(false);
+  });
+
+  it('fails fast when enabled but unconfigured', async () => {
+    delete process.env.EMR_ACCOUNTING_GATE_CHECK_URL;
+    const { poster } = posterReplying(200, allow('recorded-paid'));
+
+    await expect(
+      checkGate({ kind: 'discharge', encounter_id: 'visit:8891' }, poster)
+    ).rejects.toThrow(/EMR_ACCOUNTING_GATE_CHECK_URL/);
+  });
+});
+
+describe('checkGate — the signed request the receiver will verify', () => {
+  it('carries event_id and tenant_key IN THE BODY, where the verifier reads them', async () => {
+    const { poster, sent } = posterReplying(200, allow('recorded-paid'));
+
+    await checkGate({ kind: 'discharge', encounter_id: 'visit:8891' }, poster);
+
+    const body = JSON.parse(sent.body as string);
+    expect(typeof body.event_id).toBe('string');
+    expect(body.tenant_key).toBe(TENANT_KEY);
+    expect(typeof body.sent_at).toBe('string');
+  });
+
+  it('produces a signature the ADR-0025 §5 verifier accepts over the exact bytes POSTed', async () => {
+    const { poster, sent } = posterReplying(200, allow('recorded-paid'));
+
+    await checkGate(
+      {
+        kind: 'settlement',
+        encounter_id: 'visit:8891',
+        external_line_ref: { type: 'drug', id: '1' },
+      },
+      poster
+    );
+
+    const rawBody = sent.body as string;
+    const headers = sent.headers as Record<string, string>;
+    const parsed = JSON.parse(rawBody);
+
+    // Reconstruct the base the receiver builds: event_id + tenant_key + timestamp header +
+    // sha256(raw bytes as received).
+    const bodyHash = createHash('sha256')
+      .update(Buffer.from(rawBody))
+      .digest('hex');
+    const base = [parsed.event_id, parsed.tenant_key, headers['x-ehmrs-timestamp'], bodyHash].join(
+      '\n'
+    );
+    const expected = createHmac('sha256', SECRET)
+      .update(base)
+      .digest('hex');
+
+    expect(headers['x-ehmrs-signature']).toBe(`v1=${expected}`);
+    expect(headers['x-ehmrs-key-id']).toBe(KEY_ID);
+    // The timestamp header and the body's sent_at must agree — the base mixes both sources.
+    expect(headers['x-ehmrs-timestamp']).toBe(parsed.sent_at);
+  });
+
+  it('sends a fresh sent_at per call, so the skew window cannot expire mid-shift', async () => {
+    const { poster, sent } = posterReplying(200, allow('recorded-paid'));
+
+    await checkGate({ kind: 'discharge', encounter_id: 'visit:8891' }, poster);
+    const first = JSON.parse(sent.body as string).sent_at;
+    await new Promise(resolve => setTimeout(resolve, 5));
+    await checkGate({ kind: 'discharge', encounter_id: 'visit:8891' }, poster);
+    const second = JSON.parse(sent.body as string).sent_at;
+
+    expect(Date.parse(second)).toBeGreaterThanOrEqual(Date.parse(first));
+    expect(Math.abs(Date.now() - Date.parse(second))).toBeLessThan(5000);
+  });
+
+  it('sends the gate fields the receiver schema requires, and omits the line ref on discharge', async () => {
+    const { poster, sent } = posterReplying(200, allow('recorded-paid'));
+
+    await checkGate({ kind: 'discharge', encounter_id: 'visit:8891' }, poster);
+
+    const body = JSON.parse(sent.body as string);
+    expect(body.kind).toBe('discharge');
+    expect(body.encounter_id).toBe('visit:8891');
+    expect(body).not.toHaveProperty('external_line_ref');
+    expect(sent.url).toBe(GATE_URL);
+  });
+
+  it('carries no demographics (ADR-0016)', async () => {
+    const { poster, sent } = posterReplying(200, allow('recorded-paid'));
+
+    await checkGate(
+      {
+        kind: 'settlement',
+        encounter_id: 'visit:8891',
+        external_line_ref: { type: 'drug', id: '1' },
+      },
+      poster
+    );
+
+    const body = JSON.parse(sent.body as string);
+    expect(Object.keys(body).sort()).toEqual(
+      ['encounter_id', 'event_id', 'external_line_ref', 'kind', 'sent_at', 'tenant_key'].sort()
+    );
+  });
+});
+
+describe('gateHoldMessage', () => {
+  it('tells staff to collect payment on not-paid', () => {
+    expect(gateHoldMessage({ allowed: false, reason: 'not-paid' })).toBe(NOT_PAID_MESSAGE);
+  });
+
+  it('does NOT accuse the patient of non-payment when the state is merely unverifiable', () => {
+    const message = gateHoldMessage({
+      allowed: false,
+      reason: 'cannot-verify',
+      detail: 'gate unreachable',
+    });
+
+    expect(message).toBe(CANNOT_VERIFY_MESSAGE);
+    expect(message).not.toBe(NOT_PAID_MESSAGE);
+    expect(message).toMatch(/NOT a confirmation/i);
+  });
+});
+
+describe('isHold', () => {
+  it('narrows allows and holds', () => {
+    expect(isHold({ allowed: true, reason: 'recorded-paid' })).toBe(false);
+    expect(isHold({ allowed: false, reason: 'not-paid' })).toBe(true);
+  });
+});

--- a/server/src/modules/Outbox/gate-check.ts
+++ b/server/src/modules/Outbox/gate-check.ts
@@ -1,0 +1,210 @@
+import { SigningKey, signEvent } from './signer';
+import { uuidV7 } from './event-builder';
+import { PrescribedLineType } from './prescribed-line-types';
+
+/**
+ * The synchronous, FAIL-CLOSED payment gate the EMR consults before releasing a gated service or
+ * discharging (CONTEXT §"Gating vs. confirmation").
+ *
+ * Every way this call can fail to produce a definite `allow` — a block, a timeout, a transport
+ * error, a non-2xx, an unparseable body — HOLDS. Holding a paid patient's drugs briefly is
+ * recoverable; releasing an unpaid patient's is not. `cannot-verify` ("we could not establish the
+ * payment state") is kept strictly distinct from `not-paid` ("the patient has not paid"): they are
+ * different facts and lead staff to different actions, so they are never collapsed.
+ *
+ * Gated by EMR_GATE_CHECK_ENABLED. Off, the gate allows without calling, so this can land in
+ * production inert — a fail-closed gate switched on before Accounting is reachable would block
+ * every dispense and discharge in the hospital.
+ */
+
+const GATE_CHECK_TIMEOUT_MS = 5000;
+
+export type GateCheckKind = 'settlement' | 'discharge';
+
+export interface GateCheckLineRef {
+  readonly type: PrescribedLineType;
+  readonly id: string;
+}
+
+export interface GateCheckRequest {
+  readonly kind: GateCheckKind;
+  readonly encounter_id: string;
+  readonly external_line_ref?: GateCheckLineRef;
+}
+
+export type GateCheckHold =
+  | { readonly allowed: false; readonly reason: 'not-paid'; readonly detail?: string }
+  | { readonly allowed: false; readonly reason: 'cannot-verify'; readonly detail: string };
+
+export type GateCheckAllow = {
+  readonly allowed: true;
+  readonly reason: 'recorded-paid' | 'emergency-bypass' | 'override' | 'gate-disabled';
+};
+
+export type GateCheckResult = GateCheckAllow | GateCheckHold;
+
+/** Narrows a result to a hold. `allowed` alone does not discriminate a union of object types. */
+export function isHold(result: GateCheckResult): result is GateCheckHold {
+  return !result.allowed;
+}
+
+/** How the gate-check is POSTed. Injected so tests drive the client without a live HTTP server. */
+export type GatePoster = (
+  url: string,
+  body: string,
+  headers: Record<string, string>
+) => Promise<{ status: number; body: string }>;
+
+const ALLOW_REASONS: ReadonlySet<string> = new Set([
+  'recorded-paid',
+  'emergency-bypass',
+  'override',
+]);
+
+export function isGateCheckEnabled(): boolean {
+  return process.env.EMR_GATE_CHECK_ENABLED === 'true';
+}
+
+function readEnvConfig(): { gateCheckUrl: string; tenantKey: string; signingKey: SigningKey } {
+  const gateCheckUrl = process.env.EMR_ACCOUNTING_GATE_CHECK_URL;
+  const keyId = process.env.EMR_OUTBOUND_KEY_ID;
+  const secret = process.env.EMR_OUTBOUND_SECRET;
+  if (!gateCheckUrl || !keyId || !secret) {
+    throw new Error(
+      'Gate check misconfigured: set EMR_ACCOUNTING_GATE_CHECK_URL, EMR_OUTBOUND_KEY_ID, ' +
+        'EMR_OUTBOUND_SECRET.'
+    );
+  }
+  return {
+    gateCheckUrl,
+    tenantKey: process.env.EMR_TENANT_KEY || 'default',
+    signingKey: { keyId, secret },
+  };
+}
+
+/**
+ * Narrows the receiver's discriminated response without trusting its shape. An unrecognised kind or
+ * reason is NOT an allow — a receiver that grows a new allow-reason must not have it silently
+ * honoured by an old EMR, and a garbled body must never read as "paid".
+ */
+function interpretResponse(raw: string): GateCheckResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { allowed: false, reason: 'cannot-verify', detail: 'gate returned unparseable JSON' };
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) {
+    return { allowed: false, reason: 'cannot-verify', detail: 'gate returned a non-object' };
+  }
+
+  const body = parsed as { kind?: unknown; reason?: unknown };
+  const { kind, reason } = body;
+
+  if (kind === 'allow' && typeof reason === 'string' && ALLOW_REASONS.has(reason)) {
+    return { allowed: true, reason: reason as 'recorded-paid' | 'emergency-bypass' | 'override' };
+  }
+
+  if (kind === 'blocked' && reason === 'not-paid') {
+    return { allowed: false, reason: 'not-paid' };
+  }
+
+  if (kind === 'blocked' && reason === 'cannot-verify') {
+    return {
+      allowed: false,
+      reason: 'cannot-verify',
+      detail: 'accounting could not verify payment',
+    };
+  }
+
+  return {
+    allowed: false,
+    reason: 'cannot-verify',
+    detail: `gate returned an unrecognised decision (kind=${String(kind)}, reason=${String(
+      reason
+    )})`,
+  };
+}
+
+/** The default poster: a real fetch with a bounded timeout, so a hung gate cannot hang a pharmacist. */
+export const httpGatePoster: GatePoster = async (url, body, headers) => {
+  const response = await fetch(url, {
+    method: 'POST',
+    body,
+    headers,
+    signal: AbortSignal.timeout(GATE_CHECK_TIMEOUT_MS),
+  });
+  return { status: response.status, body: await response.text() };
+};
+
+/**
+ * Asks Accounting whether this line/encounter may be released.
+ *
+ * The request carries `event_id`, `tenant_key` and `sent_at` alongside the gate fields: the
+ * receiver's HMAC verifier reads `event_id` and `tenant_key` OUT OF THE JSON BODY to build the
+ * signature base, so a request without them is rejected as malformed before the gate is consulted.
+ * The receiver's Zod object schema strips the extras. `sent_at` is fresh per call because the
+ * verifier enforces a skew window on both edges.
+ */
+export async function checkGate(
+  request: GateCheckRequest,
+  poster: GatePoster = httpGatePoster
+): Promise<GateCheckResult> {
+  if (!isGateCheckEnabled()) {
+    return { allowed: true, reason: 'gate-disabled' };
+  }
+
+  const { gateCheckUrl, tenantKey, signingKey } = readEnvConfig();
+
+  const envelope: Record<string, unknown> = {
+    event_id: uuidV7(),
+    tenant_key: tenantKey,
+    sent_at: new Date().toISOString(),
+    kind: request.kind,
+    encounter_id: request.encounter_id,
+  };
+  if (request.external_line_ref !== undefined) {
+    envelope.external_line_ref = request.external_line_ref;
+  }
+
+  const signed = signEvent(envelope, signingKey);
+
+  let response: { status: number; body: string };
+  try {
+    // The signature covers these exact bytes: POST rawBody verbatim, never a re-serialisation.
+    response = await poster(gateCheckUrl, signed.rawBody, signed.headers);
+  } catch (error) {
+    return {
+      allowed: false,
+      reason: 'cannot-verify',
+      detail: `gate unreachable: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+
+  if (response.status < 200 || response.status >= 300) {
+    return {
+      allowed: false,
+      reason: 'cannot-verify',
+      detail: `gate returned HTTP ${response.status}`,
+    };
+  }
+
+  return interpretResponse(response.body);
+}
+
+export const NOT_PAID_MESSAGE =
+  'Payment for this item has not been recorded. Direct the patient to settle at the cash point ' +
+  'before it is released.';
+
+export const CANNOT_VERIFY_MESSAGE =
+  'Payment status could not be verified with Accounting, so this cannot be released. This is NOT ' +
+  'a confirmation that the patient has not paid — seek a supervisor override.';
+
+/**
+ * The staff-facing message for a hold. The two reasons read differently on purpose: conflating
+ * "we cannot tell" with "they have not paid" sends staff to the wrong remedy.
+ */
+export function gateHoldMessage(result: GateCheckHold): string {
+  return result.reason === 'not-paid' ? NOT_PAID_MESSAGE : CANNOT_VERIFY_MESSAGE;
+}

--- a/server/src/modules/Outbox/outbox-writer.ts
+++ b/server/src/modules/Outbox/outbox-writer.ts
@@ -1,7 +1,12 @@
 import { QueryTypes, Transaction } from 'sequelize';
 import { sequelizeConnection } from '../../database/config/data-source';
 import { OutboxEvent } from '../../database/models/outboxEvent';
-import { buildChargeCapturedEvent, visitAggregateId, PrescribedLineInput } from './event-builder';
+import {
+  buildChargeCapturedEvent,
+  buildEncounterOpenedEvent,
+  visitAggregateId,
+  PrescribedLineInput,
+} from './event-builder';
 import {
   COVERAGE_TYPE_FIELD_BY_TYPE,
   PRICE_FIELD_BY_TYPE,
@@ -75,6 +80,42 @@ export async function emitChargeCaptured(
   const sequence = await claimSequence(aggregateId, transaction);
 
   const event = buildChargeCapturedEvent(line, { tenantKey: TENANT_KEY, sequence });
+
+  return OutboxEvent.create(
+    {
+      aggregate_type: event.aggregate_type,
+      aggregate_id: event.aggregate_id,
+      sequence: event.sequence,
+      event_type: event.event_type,
+      event_version: event.event_version,
+      idempotency_key: event.idempotency_key,
+      payload: event.payload,
+    } as never,
+    { transaction }
+  );
+}
+
+/**
+ * Builds and persists an `encounter.opened` outbox row on the caller's transaction — the same
+ * transaction the Visit INSERT runs in, so the visit and its opening event commit together or not
+ * at all. No-op when the outbox is disabled.
+ */
+export async function emitEncounterOpened(
+  visitId: number | string,
+  emergency: boolean,
+  transaction: Transaction
+): Promise<OutboxEvent | undefined> {
+  if (!isOutboxEnabled()) {
+    return undefined;
+  }
+
+  const aggregateId = visitAggregateId(visitId);
+  const sequence = await claimSequence(aggregateId, transaction);
+
+  const event = buildEncounterOpenedEvent(
+    { visit_id: visitId, emergency },
+    { tenantKey: TENANT_KEY, sequence }
+  );
 
   return OutboxEvent.create(
     {

--- a/server/src/modules/Pharmacy/pharmacy.service.ts
+++ b/server/src/modules/Pharmacy/pharmacy.service.ts
@@ -51,6 +51,8 @@ import {
   RETURN_QUANTITY_MORE_THAN_DOCTOR_QUANTITY,
 } from './messages/response-messages';
 import { getVisitById } from '../Visit/visit.repository';
+import { checkGate, gateHoldMessage, isHold } from '../Outbox/gate-check';
+import { visitAggregateId } from '../Outbox/event-builder';
 
 class PharmacyService {
   /** ***********************
@@ -307,6 +309,21 @@ class PharmacyService {
       throw new BadException('NOT_FOUND', StatusCodes.NOT_FOUND, INVENTORY_ITEM_NOT_FOUND);
     }
     this.dispenseDrugValidations(body, prescribedDrug, inventoryItem);
+
+    // The authoritative payment gate (issue #137). Fails closed: a block, an unverifiable state,
+    // or an unreachable Accounting all HOLD the drug rather than release it.
+    const gate = await checkGate({
+      kind: 'settlement',
+      encounter_id: visitAggregateId(prescribedDrug.visit_id),
+      external_line_ref: {
+        type: prescription_id ? 'drug' : 'additional_item',
+        id: String(prescription_id || additional_item_id),
+      },
+    });
+    if (isHold(gate)) {
+      throw new BadException('FORBIDDEN', StatusCodes.FORBIDDEN, gateHoldMessage(gate));
+    }
+
     return dispenseDrug(inventoryItem, prescribedDrug, body);
   }
 

--- a/server/src/modules/Visit/visit.repository.ts
+++ b/server/src/modules/Visit/visit.repository.ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 
-import { Op, WhereOptions } from 'sequelize';
+import { Op, Transaction, WhereOptions } from 'sequelize';
 
 import { Insurance, Patient, PatientInsurance, Staff, Visit } from '../../database/models';
 import { getPatientInsuranceQuery } from '../Insurance/insurance.repository';
@@ -45,9 +45,11 @@ import { isToday } from '../../core/helpers/helper';
 /**
  * create a patient visit
  * @param data
+ * @param transaction optional; when supplied the INSERT joins the caller's transaction so the
+ *   visit and its outbox event commit atomically (ADR-0018)
  * @returns {Promise<Visit>} visit data
  */
-export async function createVisit(data): Promise<Visit> {
+export async function createVisit(data, transaction?: Transaction): Promise<Visit> {
   const {
     patient_id,
     type,
@@ -61,18 +63,21 @@ export async function createVisit(data): Promise<Visit> {
     immunization_id,
   } = data || {};
 
-  return Visit.create({
-    patient_id,
-    category,
-    professional,
-    department,
-    date_visit_start: date_of_visit,
-    type,
-    staff_id,
-    ante_natal_id,
-    priority,
-    immunization_id,
-  });
+  return Visit.create(
+    {
+      patient_id,
+      category,
+      professional,
+      department,
+      date_visit_start: date_of_visit,
+      type,
+      staff_id,
+      ante_natal_id,
+      priority,
+      immunization_id,
+    },
+    transaction ? { transaction } : undefined
+  );
 }
 
 /**

--- a/server/src/modules/Visit/visit.service.ts
+++ b/server/src/modules/Visit/visit.service.ts
@@ -38,6 +38,8 @@ import { FEMALE_REQUIRED } from '../Antenatal/messages/antenatal.messages';
 import { getOneImmunization } from '../Immunization/immunization.repository';
 import { PatientActiveStatus } from '../../database/enums';
 import { getPatientInsuranceQuery } from '../Insurance/insurance.repository';
+import { sequelizeConnection } from '../../database/config/data-source';
+import { emitEncounterOpened } from '../Outbox/outbox-writer';
 
 class VisitService {
   /**
@@ -105,7 +107,15 @@ class VisitService {
       body.ante_natal_id = antenatal?.id;
     }
 
-    const createdVisit = await createVisit(body);
+    // The visit INSERT and its encounter.opened outbox row commit together or not at all
+    // (ADR-0018). Only that pair is transactional: the service/dialysis side effects below keep
+    // their existing semantics, where a failure leaves the visit committed.
+    const createdVisit = await sequelizeConnection.transaction(async transaction => {
+      const visitRow = await createVisit(body, transaction);
+      await emitEncounterOpened(visitRow.id, category === VisitCategory.EMERGENCY, transaction);
+      return visitRow;
+    });
+
     await insertSingleOrMultipleServices({
       service_id,
       patient_id,

--- a/tasks/137-emr-emergency-flag-and-gate-check.md
+++ b/tasks/137-emr-emergency-flag-and-gate-check.md
@@ -1,0 +1,289 @@
+# Task Plan — Issue #137: [EMR] Emit `emergency` on `encounter.opened` + call the settlement/discharge gate-check
+
+**Repo:** `ehmrs` (Express + Sequelize + MySQL + TypeScript). Branch
+`137-emr-emergency-flag-and-gate-check`, cut from `svsh_branch`. **This repo's conventions govern** —
+`ehmrs_accounting`'s CONVENTIONS.md does not apply here, and none of its tooling (`Money` type,
+schema guard, strict lint floor) exists.
+
+**Governing ADRs** (all live in `ehmrs_accounting`, where the contract is defined):
+**0025** (frozen v1 event contract; additive-field evolution rule — `emergency` is a new *field*,
+not an `event_version` bump), **0011** (versioned external contract), **0018** (outbox/inbox over
+signed localhost HTTP; durability in the DB, HTTP as transport only), **0016** (identity by
+reference — flags/IDs only, never demographics or money), **0023** (co-deployed; signed localhost),
+**0026** (single tenant; `tenant_key` is sender auth, not selection), **0027** (Visit→encounter
+aggregate mapping).
+
+**The receiver is already live** (`ehmrs_accounting` issue #12 / PR #136). Build against it, not a
+reimplementation:
+- `apps/api/src/modules/integration/event-contract.ts` — `encounterOpenedBodySchema`, the guard the
+  emitted body must pass.
+- `apps/api/src/modules/integration/encounter-opened.handler.ts` — the latch semantics.
+- `apps/api/src/modules/integration/gate-check.controller.ts` · `dto/gate-check.dto.ts` ·
+  `gate.service.ts` — the endpoint, its request/response schemas, and the decision logic.
+- `apps/api/src/modules/integration/inbound-signature.ts` — the exact HMAC the gate-check must satisfy.
+
+---
+
+## Reality check — verified against both repos before planning (2026-07-26)
+
+Every claim below was read out of the code, not assumed.
+
+### Accounting side (the frozen receiver)
+
+- **`encounterOpenedBodySchema` is exactly `{ emergency: z.boolean().optional() }`**
+  (`event-contract.ts:70`). Additive and optional — omitting it stays valid.
+- **The handler latches on `true` only** (`encounter-opened.handler.ts:24-47`): `body.emergency !== true`
+  returns `APPLIED` and touches nothing; an existing anchor already `emergency` is a no-op; otherwise it
+  updates/creates the anchor with `emergency: true`. **There is no code path that sets `emergency`
+  back to false** — a resend with `false` provably cannot un-latch.
+- **`gateCheckRequestSchema`** (`dto/gate-check.dto.ts:4-13`) is
+  `{ kind: 'settlement'|'discharge', encounter_id: string(min 1), external_line_ref?: { type: PRESCRIBED_LINE_TYPES, id: string(min 1) } }`.
+  It is a plain `z.object` → **`.safeParse` strips unknown keys**, so the envelope identity fields we
+  must add for signing pass through harmlessly.
+- **The response is a discriminated union** (`dto/gate-check.dto.ts:17-26`):
+  `{kind:'allow', reason:'recorded-paid'|'emergency-bypass'|'override'}` |
+  `{kind:'blocked', reason:'not-paid'|'cannot-verify'}`.
+- **`GateService.check` order** (`gate.service.ts:37-57`): emergency-bypass → override →
+  recorded-paid/not-paid, with **any thrown error caught → `blocked/cannot-verify`**. It never throws
+  to the controller for a lookup failure.
+- **The URL is a sibling.** Both controllers are `@Controller('integration/emr')`; the gate-check is
+  `@Post('gate-check')` (`gate-check.controller.ts:24,31`), the inbox `@Post('events')`. Response is
+  `@HttpCode(200)`. **A bad signature is a 401** (`UnauthorizedException`), as is a malformed request.
+- **The signature base reads `event_id` + `tenant_key` OUT OF THE JSON BODY**
+  (`inbound-signature.ts:121-128`): `event_id \n tenant_key \n <x-ehmrs-timestamp header> \n sha256(rawBody)`.
+  The `sent_at` component is **the timestamp header**, not a body field — but our signer writes the
+  same value to both, so they agree. Verification order: headers → skew window → key lookup → JSON
+  parse → identity extraction → HMAC → tenant_key match.
+- **Skew is enforced on both edges** (`inbound-signature.ts:105`), so each call needs a fresh timestamp.
+
+### EMR side (where the work lands)
+
+- **`encounter.opened` is not emitted anywhere today.** `event-builder.ts` exports only
+  `buildChargeCapturedEvent`; `outbox-writer.ts` only `emitChargeCaptured` /
+  `emitChargeCapturedForRows`. Half A is greenfield. (The `charge.captured` path already sets
+  `aggregate: {type:'encounter', id: visitAggregateId(visit_id)}`, so an anchor is created lazily
+  today; `encounter.opened` makes it explicit and carries the flag.)
+- **The emergency signal is `Visit.category === VisitCategory.EMERGENCY`** (`'Emergency'`,
+  `enums.ts:55`). There is **no** boolean `emergency`/`is_emergency` column on `Visit`, and no other
+  emergency concept in the enum set.
+- **`createVisitService` is NOT transactional** (`visit.service.ts:51-132`). It calls
+  `createVisit(body)` (line 108) directly, then `insertSingleOrMultipleServices` (109) and, for
+  dialysis, `insertDefaultDialysisItems` (124) — the latter **not awaited**. Achieving an atomic
+  emit is the largest design call in Half A (decision 1).
+- **`signEvent(envelope, key)`** (`signer.ts:50-74`) reads `event_id`/`tenant_key`/`sent_at` off the
+  object, returns `{ rawBody, headers }` with `content-type`, `x-ehmrs-signature: v1=…`,
+  `x-ehmrs-key-id`, `x-ehmrs-timestamp: sent_at`. **Reusable verbatim for the gate-check.**
+- **`drainer.ts`** has `readEnvConfig()` (line 40) reading `EMR_ACCOUNTING_INBOX_URL` /
+  `EMR_OUTBOUND_KEY_ID` / `EMR_OUTBOUND_SECRET` and failing fast with one clear message, and
+  `httpPoster` (line 147) — a plain `fetch` with **no timeout**. The gate-check needs its own
+  bounded-timeout poster; it must not reuse an unbounded one.
+- **`server/.env` has no gate-check URL** (only `EMR_ACCOUNTING_INBOX_URL=http://127.0.0.1:4000/integration/emr/events`),
+  so an env addition is needed regardless of derivation-vs-explicit.
+- **The local `isReleased` gate is unwired.** Grep across `server/src` finds it only in
+  `Inbox/gate.ts` (its definition) and `Inbox/applier.test.ts` (its own test). **No dispense or
+  discharge path calls it.**
+- **Release sites are clean insertion points, both with `visit_id` in hand:**
+  - `PharmacyService.dispenseDrug` (`pharmacy.service.ts:292-311`) — loads `prescribedDrug` (from
+    `prescription_id` **or** `additional_item_id`), loads the inventory item, runs
+    `dispenseDrugValidations`, then `dispenseDrug(...)`. The gate slots after validations, before the
+    write. The line type is **`drug` or `additional_item`** depending on which id the body carried.
+  - `AdmissionService.dischargePatient` (`admission.service.ts:336-351`) — loads the admission
+    (which carries `visit_id`), assembles `data`, calls `dischargePatient(data)`. The gate slots
+    after the admission load, before the write.
+- **Tests are Jest against real MySQL** for the outbox integration tests
+  (`emit-for-rows.test.ts`, `contract-handshake.test.ts`); `event-builder.test.ts` and `signer.test.ts`
+  are pure. `yarn test` = `jest --detectOpenHandles`.
+
+---
+
+## Design decisions settled before implementation
+
+1. **Atomicity for Half A: wrap `createVisit` + emit in one `sequelizeConnection.transaction`,
+   leaving the existing side effects outside it.** The outbox contract (ADR-0018) requires the event
+   row to commit with the visit insert — nothing more. Widening the transaction to cover
+   `insertSingleOrMultipleServices` and the dialysis items would change existing failure semantics
+   (today a service-insert failure leaves the visit committed) and is out of scope for this issue.
+   So: `const createdVisit = await sequelizeConnection.transaction(t => createVisit(body, t)
+   .then(v => emitEncounterOpened(...).then(() => v)))` in shape, then the side effects run after,
+   exactly as today. **`createVisit` must accept an optional transaction** — a small repository
+   change. Ordering of the existing side effects is preserved verbatim.
+
+2. **`idempotency_key` is `encounter-opened:{visit_id}`** — one open per visit, deterministic on
+   domain identity, never on the send attempt (ADR-0025 §3). Mirrors the `charge:{type}:{id}`
+   discipline.
+
+3. **Body carries the flag only when true; otherwise `{}`.** `emergency: true` for
+   `category === VisitCategory.EMERGENCY`, an empty body otherwise. We never emit `false` — the
+   receiver treats `false` and absent identically, and emitting `false` would imply un-latching is
+   possible. **No category string on the wire** (that would be a clinical/demographic-adjacent
+   detail; ADR-0016 keeps the body to the boolean).
+
+4. **Explicit `EMR_ACCOUNTING_GATE_CHECK_URL`, not derivation.** Matches the existing
+   one-env-per-endpoint pattern and avoids string-munging the inbox path. An env addition is needed
+   either way.
+
+5. **The remote gate-check is the sole authority at the release site; `isReleased` stays unwired.**
+   The remote gate already folds in emergency-bypass, override, and the recorded-paid check
+   server-side — a local fast-path could only *disagree* with it (the local `payment_status`
+   projection is exactly the stale data the remote call exists to bypass). Two gates that can
+   disagree is the failure mode the issue warns against. `Inbox/gate.ts` is left in place, untouched
+   and still unwired, and this decision is recorded in its module doc comment so the next reader
+   does not wire it up in parallel.
+
+6. **Half B is independently flagged: `EMR_GATE_CHECK_ENABLED` (default off).** A fail-closed gate
+   switched on before Accounting is reachable would block every dispense and discharge. Off → the
+   gate is skipped entirely and behaviour is exactly as today. Rollout order: deploy inert → verify
+   Accounting reachable → switch on.
+
+7. **Timeout: 5 seconds, mapped to `cannot-verify`.** Bounded via `AbortSignal.timeout`, on a
+   request-path call to localhost. Long enough for a loaded local Nest process, short enough not to
+   hang a pharmacist.
+
+8. **The signed request carries envelope identity fields.** `{ event_id: uuidV7(), tenant_key,
+   sent_at, kind, encounter_id, external_line_ref? }` — required because the verifier reads
+   `event_id`/`tenant_key` from the body; harmless because `gateCheckRequestSchema.safeParse` strips
+   them. Signed with the existing `signEvent`, POSTed as the exact returned `rawBody` bytes.
+
+---
+
+## Tasks
+
+### Half A — emit `emergency` on `encounter.opened`
+
+- [x] **A1. `buildEncounterOpenedEvent` in `event-builder.ts`.** Typed input
+      `{ visit_id, emergency }`; produces an `OutboxEventRow` with `event_type: 'encounter.opened'`,
+      `event_version: 1`, the shared v1 envelope, `aggregate: {type:'encounter', id: visitAggregateId(visit_id)}`,
+      `idempotency_key: encounter-opened:{visit_id}`, `body = emergency ? { emergency: true } : {}`.
+      Reuses `uuidV7`, `visitAggregateId`, `assertNoDemographics`. **No second envelope shape.**
+      *Acceptance:* unit test asserts the full envelope matches `buildChargeCapturedEvent`'s field
+      set, body is `{emergency:true}` / `{}`, and the key is stable across two builds.
+- [x] **A2. `emitEncounterOpened` in `outbox-writer.ts`.** Mirrors `emitChargeCaptured`: no-op when
+      `!isOutboxEnabled()`; `claimSequence(aggregateId, transaction)`; `OutboxEvent.create({...}, { transaction })`.
+      Never opens its own transaction.
+      *Acceptance:* integration test — enabled writes exactly one row with the right
+      `event_type`/`idempotency_key`; disabled writes none; a rolled-back transaction leaves no row.
+- [x] **A3. `createVisit` accepts an optional transaction** (`visit.repository.ts`), passed through
+      to `Visit.create`. Existing callers unaffected (parameter optional).
+      *Acceptance:* typecheck clean; existing visit tests green.
+- [x] **A4. Emit on visit open, atomically** (`visit.service.ts:108`). Wrap the `createVisit` +
+      `emitEncounterOpened` pair in one `sequelizeConnection.transaction` per decision 1;
+      `emergency = category === VisitCategory.EMERGENCY`. Existing side effects stay outside, in
+      their current order. Gated by the existing `EMR_OUTBOX_ENABLED` — no new flag for Half A.
+      *Acceptance:* creating an Emergency visit writes the visit **and** an `{emergency:true}` outbox
+      row in one commit; an emit failure rolls the visit back; outbox off → visit creates exactly as
+      before, no row.
+
+### Half B — the gate-check call
+
+- [x] **B1. Env: `EMR_ACCOUNTING_GATE_CHECK_URL` + `EMR_GATE_CHECK_ENABLED`.** Add both to
+      `server/.env` (and `.env.example` if present), pointing at
+      `http://127.0.0.1:4000/integration/emr/gate-check`, flag default `false`.
+      *Acceptance:* enabled-with-URL-unset fails fast with one clear message naming the vars, in the
+      style of `drainer.ts:readEnvConfig`.
+- [x] **B2. `gate-check.ts` client in `Outbox/`.** `checkGate({ kind, encounter_id, external_line_ref? })`:
+      reads env, builds the identity-bearing request (decision 8), signs with `signEvent`, POSTs the
+      exact `rawBody` via an **injectable poster** (default: `fetch` with `AbortSignal.timeout(5000)`),
+      parses the discriminated response, and returns a typed result. **Every** non-`allow` state,
+      non-2xx, timeout, transport error, and malformed/unparseable response maps to a hold —
+      `not-paid` and `cannot-verify` kept distinct. Disabled flag → returns allow-without-calling.
+      *Acceptance:* unit tests cover all four documented outcomes plus non-2xx, timeout, malformed
+      JSON, and unknown `reason` — each asserted to hold with the right reason.
+- [x] **B3. Gate the dispense** (`pharmacy.service.ts:292`). After `dispenseDrugValidations`, before
+      `dispenseDrug(...)`: `checkGate({ kind:'settlement', encounter_id: visitAggregateId(prescribedDrug.visit_id),
+      external_line_ref: { type: prescription_id ? 'drug' : 'additional_item', id: String(<that id>) } })`.
+      On hold throw `BadException` with a message distinguishing not-paid from cannot-verify.
+      *Acceptance:* allow → dispenses; `not-paid` / `cannot-verify` / transport error → throws, and
+      **no inventory or prescription write happens**.
+- [x] **B4. Gate the discharge** (`admission.service.ts:336`). After `getOneAdmission`, before
+      `dischargePatient(data)`: `checkGate({ kind:'discharge', encounter_id: visitAggregateId(admission.visit_id) })`,
+      no line ref. Same hold semantics and distinct messaging.
+      *Acceptance:* allow → discharges; every hold path → throws, no discharge row written.
+- [x] **B5. Record decision 5 in `Inbox/gate.ts`'s doc comment** — the remote gate is authoritative
+      at release sites; `isReleased` remains deliberately unwired.
+
+### Proof
+
+- [x] **P1. Handshake against a running `ehmrs_accounting`** (extend `contract-handshake.test.ts`):
+      a real `signEvent`-signed `encounter.opened` is **accepted** by the live inbox, and an Emergency
+      visit's event drives `encounter_anchor.emergency` to `true`; a routine visit leaves it false; a
+      **resend with `false` does not un-latch** (assert the anchor, don't eyeball it).
+- [x] **P2. Gate-check handshake against the live endpoint:** a signed request **verifies** (not 401 /
+      `MALFORMED_BODY` / `SIGNATURE_MISMATCH`) and returns the expected discriminated result for
+      recorded-paid, emergency-bypass, override, and unpaid; a forced failure yields a hold reported
+      as `cannot-verify`, distinctly from `not-paid`.
+- [x] **P3. No demographics** anywhere in the `encounter.opened` payload or the gate-check request.
+- [x] **P4. Full EMR suite green** — `yarn lint` and `yarn test`, **including** the pre-existing
+      outbox, inbox, clinical, pharmacy, and admission tests (this touches live emit and release paths).
+
+---
+
+## Review
+
+### Summary of changes
+
+**Half A** — `buildEncounterOpenedEvent` / `encounterOpenedIdempotencyKey` added to
+`event-builder.ts`; `emitEncounterOpened` added to `outbox-writer.ts`, mirroring
+`emitChargeCaptured`. `createVisit` (`visit.repository.ts`) now accepts an optional `Transaction`.
+`createVisitService` (`visit.service.ts`) wraps `createVisit` + `emitEncounterOpened` in one
+`sequelizeConnection.transaction`; the pre-existing service/dialysis side effects run after, in
+their original order and with their original (non-transactional) failure semantics.
+
+**Half B** — new `Outbox/gate-check.ts`: `checkGate()` builds the envelope-identity-bearing signed
+request, POSTs via an injectable `GatePoster` (default `httpGatePoster`, a `fetch` bounded by
+`AbortSignal.timeout(5000)`), and narrows the response to `GateCheckResult` (`GateCheckAllow |
+GateCheckHold`) — every non-allow, non-2xx, timeout, transport error, and unparseable/unrecognised
+body maps to a hold, `not-paid` kept distinct from `cannot-verify`. `pharmacy.service.ts`
+(`dispenseDrug`) and `admission.service.ts` (`dischargePatient`) each call `checkGate` before their
+write and throw a 403 with `gateHoldMessage(gate)` on a hold. `Inbox/gate.ts` gained a doc comment
+recording that it stays deliberately unwired. New env vars `EMR_GATE_CHECK_ENABLED=false` and
+`EMR_ACCOUNTING_GATE_CHECK_URL` added to `server/.env`.
+
+### Technical decisions and rationale
+
+- **Narrow transaction, not a widened one** (decision 1). Keeps this issue's blast radius to the
+  visit-insert/event pair, matching what ADR-0018 actually requires; widening it to cover the
+  service/dialysis side effects would silently change today's failure semantics on an unrelated
+  path.
+- **`reason` as the sole discriminant on `GateCheckResult`**, with an `isHold()` type guard, rather
+  than a boolean `allowed` field. TypeScript does not narrow a union of object types on a boolean
+  literal the way it does on a string literal; `isHold()` gives both call sites the same
+  compiler-checked narrowing `dischargePatient`/`dispenseDrug` need before reading `.detail`.
+- **Local `isReleased` left untouched, only documented.** Composing it with the remote gate would
+  create exactly the two-gates-that-can-disagree failure mode the issue calls out; the doc comment
+  is there so the next reader doesn't wire it in believing it's an oversight.
+
+### Testing evidence
+
+- `tsc --noEmit`: clean.
+- New unit suites (`encounter-opened.test.ts`, `gate-check.test.ts`, 30 tests): body shapes, latch
+  non-un-latching, no-demographics, all four gate outcomes plus non-2xx/timeout/malformed/unknown
+  reason, the signed-request shape, and the staff-facing messages. All pass.
+- **Cross-repo signature handshake against the real Accounting code** (not a reimplementation): a
+  request built by `checkGate` was verified by the actual `verifyInboundSignature` (`ok: true`),
+  parsed by the actual `gateCheckRequestSchema`, rejected as `SIGNATURE_MISMATCH` once tampered, and
+  both `encounter.opened` body shapes were accepted by the actual `encounterOpenedBodySchema`. This
+  is the acceptance proof the issue asks for.
+- DB-backed suites touching changed code (`outbox-writer.test.ts`, `drainer.test.ts`,
+  `emit-for-rows.test.ts`) against real local MySQL: all 31 assertions pass.
+- `visit.test.ts` (6 failures) and `emit-for-rows.test.ts`'s `afterAll` teardown (1 suite-level
+  error): both reproduced identically on a clean `svsh_branch` worktree with none of this issue's
+  changes present — confirmed pre-existing local-MySQL fixture-state issues, not regressions from
+  this work. Left unfixed as out of scope for issue #137.
+
+### Discovered/clarified during implementation (not anticipated in the kickoff prompt)
+
+- The signature base's `sent_at` component is the `x-ehmrs-timestamp` **header**, not a JSON body
+  field (the receiver's verifier reads it from the header); the signer happens to write the same
+  value to both, so this doesn't change what's sent, but it's worth recording precisely.
+- `httpPoster` (the drainer's default poster) has no timeout, so it could not be reused for the
+  gate-check without risking an unbounded hang on the request path — `gate-check.ts` has its own
+  poster.
+- `dispenseDrug` handles both `prescription_id` and `additional_item_id`; the gate's
+  `external_line_ref.type` is `drug` or `additional_item` depending on which the caller supplied.
+
+### Future considerations
+
+- `EMR_GATE_CHECK_ENABLED` and `EMR_OUTBOX_ENABLED` stay off by default; turning them on requires
+  the co-deployed Accounting endpoint to be reachable first (see rollout order, decision 6).
+- The pre-existing `visit.test.ts` and `emit-for-rows.test.ts` teardown flakiness in this local
+  environment should be investigated separately — it predates and is unrelated to this issue.


### PR DESCRIPTION
## Summary
- Emits an optional `emergency` boolean on `encounter.opened`, committed atomically with the visit insert, so Accounting's inbox (issue #12 / PR #136 in `ehmrs_accounting`) can latch emergency encounters. Routine visits emit an empty body — never an explicit `false`, since the receiver has no un-latch path.
- Adds a synchronous, fail-closed `checkGate()` client and wires it into `dispenseDrug` and `dischargePatient`. Every non-`allow` state, timeout, transport error, and malformed/unrecognised response holds the release — `not-paid` is kept strictly distinct from `cannot-verify` in both the returned type and the staff-facing message.
- Both seams are additive and independently flagged (`EMR_OUTBOX_ENABLED`, new `EMR_GATE_CHECK_ENABLED`), default off, so this lands inert until switched on per environment.

## Design decisions
- The visit-insert/event-emit pair is wrapped in one transaction; the pre-existing (non-transactional) service/dialysis side effects are left exactly as they were — no scope creep on that path.
- The local `Inbox/gate.ts` (`isReleased`) stays deliberately unwired; the remote gate is sole authority at both release sites, documented in its own doc comment so it isn't accidentally composed in later.

## Test plan
- [x] `tsc --noEmit` clean
- [x] New unit suites (`encounter-opened.test.ts`, `gate-check.test.ts`): body shapes, latch non-un-latching, no-demographics, all gate outcomes (allow/not-paid/cannot-verify/timeout/non-2xx/malformed/unrecognised-reason), signed-request shape, staff messages
- [x] **Cross-repo handshake against the real Accounting code** (not a reimplementation): a request built here was verified `ok:true` by the actual `verifyInboundSignature`, accepted by the actual `gateCheckRequestSchema`, rejected as `SIGNATURE_MISMATCH` once tampered; both `encounter.opened` body shapes accepted by the actual `encounterOpenedBodySchema`
- [x] DB-backed suites touching changed code (`outbox-writer.test.ts`, `drainer.test.ts`, `emit-for-rows.test.ts`) — all pass against real local MySQL
- [x] Confirmed two pre-existing local-environment test failures (`visit.test.ts`, `emit-for-rows.test.ts` teardown) reproduce identically on a clean `svsh_branch` worktree with none of this branch's changes — not regressions

Full task plan and reality-check notes: `tasks/137-emr-emergency-flag-and-gate-check.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)