### PR TITLE
feat(outbox): emit charge.voided and encounter.closed on visit end (#163)

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "description": "Electronic Health Management Resource System",
   "main": "app.js",
   "scripts": {
-    "test": "jest --detectOpenHandles",
+    "test": "jest --detectOpenHandles --forceExit",
     "test:db:setup": "node src/database/test-schema/setup-test-db.js",
     "start:dev": "nodemon",
     "start": "node dist/app.js",

--- a/server/src/core/command/jobs/cron/endVisits.job.ts
+++ b/server/src/core/command/jobs/cron/endVisits.job.ts
@@ -5,13 +5,15 @@ import { VisitCategory, VisitStatus } from '../../../../database/enums';
 import dayjs from 'dayjs';
 import { processTasksExecution } from '../../../helpers/tasksProcessor';
 import { Op } from 'sequelize';
+import { sequelizeConnection } from '../../../../database/config/data-source';
+import { endVisitAndEmitOutboxEvents } from '../../../../modules/Outbox/visit-close-emission';
 
-const visitHandler = async (visit: Visit) => {
+export const visitHandler = async (visit: Visit) => {
   const message = taggedMessaged('visitHandler');
-  await Visit.update(
-    { status: VisitStatus.ENDED, date_visit_ended: Date.now() },
-    { where: { id: visit.id } }
-  );
+  const occurredAt = new Date();
+  await sequelizeConnection.transaction(async transaction => {
+    await endVisitAndEmitOutboxEvents(visit, occurredAt, transaction);
+  });
   logger.notice(message(`Ended visit for patient ${visit.patient_id}`));
 };
 
@@ -47,21 +49,40 @@ export const endVisits = async () => {
     }),
   ]);
 
-  const visits = [
-    ...antenatalVisits,
-    ...todayUntakenVisits,
-    ...fiveDaysAgoVisits,
-    ...immunizationVisits,
-  ];
+  const visits = Array.from(
+    new Map(
+      [
+        ...antenatalVisits,
+        ...todayUntakenVisits,
+        ...fiveDaysAgoVisits,
+        ...immunizationVisits,
+      ].map(visit => [visit.id, visit])
+    ).values()
+  );
 
   try {
     if (visits?.length) {
-      await processTasksExecution({
+      const { errors } = await processTasksExecution({
         tasks: visits,
         message,
         concurrency: 10,
-        handler: visitHandler,
+        handler: async task => {
+          try {
+            await visitHandler(task);
+          } catch (error) {
+            logger.error(message(`Failed to end visit ${task.id}`), {
+              visitId: task.id,
+              error,
+            });
+            throw error;
+          }
+        },
       });
+      if (errors.length > 0) {
+        logger.error(message(`${errors.length} visit(s) failed to end`), {
+          errors: errors.map(error => error.message),
+        });
+      }
       return;
     }
     logger.notice(message(`No visits to end`));

--- a/server/src/modules/Outbox/charge-voided.test.ts
+++ b/server/src/modules/Outbox/charge-voided.test.ts
@@ -1,0 +1,53 @@
+import {
+  EventBuildError,
+  buildChargeVoidedEvent,
+  chargeIdempotencyKey,
+  chargeVoidedIdempotencyKey,
+} from './event-builder';
+
+const context = {
+  tenantKey: 'lagoon_general',
+  sequence: 7,
+  occurredAt: new Date('2026-07-26T10:00:00.000Z'),
+  sentAt: new Date('2026-07-26T10:00:01.000Z'),
+};
+
+describe('chargeVoidedIdempotencyKey', () => {
+  it('is deterministic and distinct from the capture key', () => {
+    expect(chargeVoidedIdempotencyKey('drug', 42)).toBe('charge-voided:drug:42');
+    expect(chargeVoidedIdempotencyKey('drug', 42)).not.toBe(chargeIdempotencyKey('drug', 42));
+  });
+
+  it('refuses an unknown type', () => {
+    expect(() => chargeVoidedIdempotencyKey('unknown' as never, 1)).toThrow(EventBuildError);
+  });
+});
+
+describe('buildChargeVoidedEvent', () => {
+  it('carries external_line_ref and encounter_id only', () => {
+    const row = buildChargeVoidedEvent({ type: 'drug', id: 42, visit_id: 8891 }, context);
+
+    expect(row.event_type).toBe('charge.voided');
+    expect(row.payload.body).toEqual({
+      external_line_ref: { type: 'drug', id: '42' },
+      encounter_id: 'visit:8891',
+    });
+  });
+
+  it('carries no money field under any input', () => {
+    const row = buildChargeVoidedEvent({ type: 'service', id: 9, visit_id: 8891 }, context);
+    const body = row.payload.body as Record<string, unknown>;
+    const keys = Object.keys(body);
+
+    expect(keys).not.toContain('amount_kobo');
+    expect(keys).not.toContain('amount');
+    expect(keys).not.toContain('price');
+    expect(keys).not.toContain('kobo');
+  });
+
+  it('refuses an unknown type', () => {
+    expect(() =>
+      buildChargeVoidedEvent({ type: 'unknown' as never, id: 1, visit_id: 8891 }, context)
+    ).toThrow(EventBuildError);
+  });
+});

--- a/server/src/modules/Outbox/contract-handshake.test.ts
+++ b/server/src/modules/Outbox/contract-handshake.test.ts
@@ -1,5 +1,10 @@
 import { createHash, createHmac } from 'crypto';
-import { buildChargeCapturedEvent, buildPatientDemographicsChangedEvent } from './event-builder';
+import {
+  buildChargeCapturedEvent,
+  buildChargeVoidedEvent,
+  buildEncounterClosedEvent,
+  buildPatientDemographicsChangedEvent,
+} from './event-builder';
 import { signEvent } from './signer';
 
 /**
@@ -167,6 +172,30 @@ describe('EMR outbox ↔ Accounting inbox handshake', () => {
     expect(verifyLikeAccounting(Buffer.from(signed.rawBody), signed.headers)).toEqual({
       ok: true,
       keyId: 'emr-2026-07',
+    });
+  });
+
+  it('a signed charge.voided is ACCEPTED by the verifier', () => {
+    const row = buildChargeVoidedEvent(
+      { type: 'drug', id: 42, visit_id: 8891 },
+      { tenantKey: TENANT_KEY, sequence: 43 }
+    );
+    const signed = signEvent(row.payload, SHARED_KEY);
+    expect(verifyLikeAccounting(Buffer.from(signed.rawBody), signed.headers)).toEqual({
+      ok: true,
+      keyId: SHARED_KEY.keyId,
+    });
+  });
+
+  it('a signed encounter.closed is ACCEPTED by the verifier', () => {
+    const row = buildEncounterClosedEvent(
+      { visit_id: 8891 },
+      { tenantKey: TENANT_KEY, sequence: 44 }
+    );
+    const signed = signEvent(row.payload, SHARED_KEY);
+    expect(verifyLikeAccounting(Buffer.from(signed.rawBody), signed.headers)).toEqual({
+      ok: true,
+      keyId: SHARED_KEY.keyId,
     });
   });
 

--- a/server/src/modules/Outbox/encounter-closed.test.ts
+++ b/server/src/modules/Outbox/encounter-closed.test.ts
@@ -1,0 +1,70 @@
+import {
+  buildChargeCapturedEvent,
+  buildEncounterClosedEvent,
+  encounterClosedIdempotencyKey,
+} from './event-builder';
+
+const context = {
+  tenantKey: 'lagoon_general',
+  sequence: 7,
+  occurredAt: new Date('2026-07-26T10:00:00.000Z'),
+  sentAt: new Date('2026-07-26T10:00:01.000Z'),
+};
+
+describe('encounterClosedIdempotencyKey', () => {
+  it('is deterministic on the visit, so a redelivery dedupes at the inbox', () => {
+    expect(encounterClosedIdempotencyKey(8891)).toBe('encounter-closed:8891');
+    expect(encounterClosedIdempotencyKey(8891)).toBe(encounterClosedIdempotencyKey('8891'));
+  });
+});
+
+describe('buildEncounterClosedEvent', () => {
+  it('emits an empty body', () => {
+    const row = buildEncounterClosedEvent({ visit_id: 8891 }, context);
+
+    expect(row.event_type).toBe('encounter.closed');
+    expect(row.payload.body).toEqual({});
+  });
+
+  it('carries no patient, category, or closed_at in the body (ADR-0016)', () => {
+    const row = buildEncounterClosedEvent({ visit_id: 8891 }, context);
+    const serialised = JSON.stringify(row.payload.body);
+
+    expect(Object.keys(row.payload.body as Record<string, unknown>)).toHaveLength(0);
+    for (const leak of ['patient', 'name', 'category', 'closed_at', 'date_visit_ended']) {
+      expect(serialised).not.toContain(leak);
+    }
+  });
+
+  it('reuses the v1 envelope shape charge.captured already produces', () => {
+    const closed = buildEncounterClosedEvent({ visit_id: 8891 }, context);
+    const charge = buildChargeCapturedEvent(
+      {
+        type: 'drug',
+        id: 1,
+        patient_id: 100,
+        visit_id: 8891,
+        amount: '2500.00',
+        quantity: 2,
+        service_date: '2026-07-26',
+      },
+      context
+    );
+
+    expect(Object.keys(closed.payload).sort()).toEqual(Object.keys(charge.payload).sort());
+    expect(closed.payload.aggregate).toEqual(charge.payload.aggregate);
+    expect(closed.payload.event_version).toBe(1);
+    expect(closed.payload.tenant_key).toBe('lagoon_general');
+    expect(closed.payload.event_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+    );
+  });
+
+  it('anchors on the visit aggregate so the anchor matches charge.captured', () => {
+    const row = buildEncounterClosedEvent({ visit_id: 8891 }, context);
+
+    expect(row.aggregate_type).toBe('encounter');
+    expect(row.aggregate_id).toBe('visit:8891');
+    expect(row.idempotency_key).toBe('encounter-closed:8891');
+  });
+});

--- a/server/src/modules/Outbox/event-builder.ts
+++ b/server/src/modules/Outbox/event-builder.ts
@@ -193,6 +193,19 @@ export function encounterOpenedIdempotencyKey(visitId: number | string): string 
   return `encounter-opened:${visitId}`;
 }
 
+export function encounterClosedIdempotencyKey(visitId: number | string): string {
+  return `encounter-closed:${visitId}`;
+}
+
+export function chargeVoidedIdempotencyKey(type: PrescribedLineType, id: number | string): string {
+  if (!isPrescribedLineType(type)) {
+    throw new EventBuildError(
+      `Unknown prescribed-line type "${type}"; expected one of ${PRESCRIBED_LINE_TYPES.join(', ')}`
+    );
+  }
+  return `charge-voided:${type}:${id}`;
+}
+
 export interface OutboxEventRow {
   readonly aggregate_type: string;
   readonly aggregate_id: string;
@@ -284,6 +297,103 @@ export interface EncounterOpenedInput {
  * path that clears it, so a `false` is indistinguishable from an absent field at the receiver —
  * emitting one would falsely imply an encounter can be corrected back to routine.
  */
+export interface EncounterClosedInput {
+  readonly visit_id: number | string;
+}
+
+export interface ChargeVoidedInput {
+  readonly type: PrescribedLineType;
+  readonly id: number | string;
+  readonly visit_id: number | string;
+}
+
+export function buildEncounterClosedEvent(
+  input: EncounterClosedInput,
+  context: BuildContext
+): OutboxEventRow {
+  const encounterId = visitAggregateId(input.visit_id);
+  const occurredAt = context.occurredAt ?? new Date();
+  const sentAt = context.sentAt ?? new Date();
+  const idempotencyKey = encounterClosedIdempotencyKey(input.visit_id);
+  const eventVersion = context.eventVersion ?? 1;
+
+  const body: Record<string, unknown> = {};
+
+  assertNoDemographics(body, 'encounter.closed');
+
+  const payload: Record<string, unknown> = {
+    event_id: uuidV7(context.now),
+    event_type: 'encounter.closed',
+    event_version: eventVersion,
+    tenant_key: context.tenantKey,
+    occurred_at: occurredAt.toISOString(),
+    sent_at: sentAt.toISOString(),
+    aggregate: { type: 'encounter', id: encounterId },
+    sequence: Number(context.sequence),
+    idempotency_key: idempotencyKey,
+    body,
+  };
+
+  return {
+    aggregate_type: 'encounter',
+    aggregate_id: encounterId,
+    sequence: context.sequence,
+    event_type: 'encounter.closed',
+    event_version: eventVersion,
+    idempotency_key: idempotencyKey,
+    payload,
+  };
+}
+
+export function buildChargeVoidedEvent(
+  input: ChargeVoidedInput,
+  context: BuildContext
+): OutboxEventRow {
+  if (!isPrescribedLineType(input.type)) {
+    throw new EventBuildError(
+      `Unknown prescribed-line type "${input.type}"; expected one of ${PRESCRIBED_LINE_TYPES.join(
+        ', '
+      )}`
+    );
+  }
+
+  const encounterId = visitAggregateId(input.visit_id);
+  const occurredAt = context.occurredAt ?? new Date();
+  const sentAt = context.sentAt ?? new Date();
+  const idempotencyKey = chargeVoidedIdempotencyKey(input.type, input.id);
+  const eventVersion = context.eventVersion ?? 1;
+
+  const body: Record<string, unknown> = {
+    external_line_ref: { type: input.type, id: String(input.id) },
+    encounter_id: encounterId,
+  };
+
+  assertNoDemographics(body, 'charge.voided');
+
+  const payload: Record<string, unknown> = {
+    event_id: uuidV7(context.now),
+    event_type: 'charge.voided',
+    event_version: eventVersion,
+    tenant_key: context.tenantKey,
+    occurred_at: occurredAt.toISOString(),
+    sent_at: sentAt.toISOString(),
+    aggregate: { type: 'encounter', id: encounterId },
+    sequence: Number(context.sequence),
+    idempotency_key: idempotencyKey,
+    body,
+  };
+
+  return {
+    aggregate_type: 'encounter',
+    aggregate_id: encounterId,
+    sequence: context.sequence,
+    event_type: 'charge.voided',
+    event_version: eventVersion,
+    idempotency_key: idempotencyKey,
+    payload,
+  };
+}
+
 export function buildEncounterOpenedEvent(
   input: EncounterOpenedInput,
   context: BuildContext

--- a/server/src/modules/Outbox/outbox-writer.ts
+++ b/server/src/modules/Outbox/outbox-writer.ts
@@ -1,20 +1,30 @@
-import { QueryTypes, Transaction } from 'sequelize';
+import { Model, ModelStatic, QueryTypes, Transaction } from 'sequelize';
 import { sequelizeConnection } from '../../database/config/data-source';
 import { OutboxEvent } from '../../database/models/outboxEvent';
 import { Patient } from '../../database/models/patient';
 import { PatientInsurance } from '../../database/models/patientInsurance';
+import { PrescribedAdditionalItem } from '../../database/models/prescribedAdditionalItem';
+import { PrescribedDrug } from '../../database/models/prescribedDrug';
+import { PrescribedInvestigation } from '../../database/models/prescribedInvestigation';
+import { PrescribedService } from '../../database/models/prescribedService';
+import { PrescribedTest } from '../../database/models/prescribedTest';
 import {
   buildChargeCapturedEvent,
+  buildChargeVoidedEvent,
+  buildEncounterClosedEvent,
   buildEncounterOpenedEvent,
   buildPatientDemographicsChangedEvent,
   patientAggregateId,
   visitAggregateId,
   PrescribedLineInput,
+  ChargeVoidedInput,
 } from './event-builder';
 import {
   COVERAGE_TYPE_FIELD_BY_TYPE,
+  PRESCRIBED_LINE_TYPES,
   PRICE_FIELD_BY_TYPE,
   PrescribedLineType,
+  VOIDABLE_PREDICATE_BY_TYPE,
 } from './prescribed-line-types';
 import { PayerResolver } from './payer-derivation';
 
@@ -31,8 +41,83 @@ import { PayerResolver } from './payer-derivation';
 
 const TENANT_KEY = process.env.EMR_TENANT_KEY || 'default';
 
+export const MODEL_BY_TYPE: Record<PrescribedLineType, ModelStatic<Model>> = {
+  drug: (PrescribedDrug as unknown) as ModelStatic<Model>,
+  investigation: (PrescribedInvestigation as unknown) as ModelStatic<Model>,
+  service: (PrescribedService as unknown) as ModelStatic<Model>,
+  test: (PrescribedTest as unknown) as ModelStatic<Model>,
+  additional_item: (PrescribedAdditionalItem as unknown) as ModelStatic<Model>,
+};
+
+function buildContext(sequence: number, occurredAt: Date) {
+  return { tenantKey: TENANT_KEY, sequence, occurredAt, sentAt: occurredAt };
+}
+
+const IDEMPOTENT_SKIP_EVENT_TYPES = new Set(['charge.voided', 'encounter.closed']);
+
+async function persistOutboxEvent(
+  event: {
+    aggregate_type: string;
+    aggregate_id: string;
+    sequence: number | string;
+    event_type: string;
+    event_version: number;
+    idempotency_key: string;
+    payload: Record<string, unknown>;
+  },
+  transaction: Transaction
+): Promise<OutboxEvent> {
+  if (IDEMPOTENT_SKIP_EVENT_TYPES.has(event.event_type)) {
+    const existing = await OutboxEvent.findOne({
+      where: { idempotency_key: event.idempotency_key },
+      transaction,
+    });
+    if (existing) {
+      return existing;
+    }
+  }
+
+  return OutboxEvent.create(
+    {
+      aggregate_type: event.aggregate_type,
+      aggregate_id: event.aggregate_id,
+      sequence: event.sequence,
+      event_type: event.event_type,
+      event_version: event.event_version,
+      idempotency_key: event.idempotency_key,
+      payload: event.payload,
+    } as never,
+    { transaction }
+  );
+}
+
 export function isOutboxEnabled(): boolean {
   return process.env.EMR_OUTBOX_ENABLED === 'true';
+}
+
+/**
+ * Claims a block of sequential sequences for an aggregate, inside the caller's transaction.
+ */
+export async function claimSequences(
+  aggregateId: string,
+  count: number,
+  transaction: Transaction
+): Promise<number> {
+  if (count <= 0) {
+    throw new Error('Outbox: count must be greater than 0');
+  }
+  await sequelizeConnection.query(
+    `INSERT INTO Outbox_Sequences (aggregate_id, last_sequence, createdAt, updatedAt)
+     VALUES (:aggregateId, LAST_INSERT_ID(:count), NOW(), NOW())
+     ON DUPLICATE KEY UPDATE last_sequence = LAST_INSERT_ID(last_sequence + :count), updatedAt = NOW()`,
+    { replacements: { aggregateId, count }, transaction, type: QueryTypes.INSERT }
+  );
+
+  const [row] = await sequelizeConnection.query<{ seq: number }>('SELECT LAST_INSERT_ID() AS seq', {
+    transaction,
+    type: QueryTypes.SELECT,
+  });
+  return Number(row.seq);
 }
 
 /**
@@ -47,22 +132,8 @@ export function isOutboxEnabled(): boolean {
  * aggregate" and "nth event" cases into one atomic statement that also takes the row lock, so
  * there is no read-then-write window for a concurrent transaction to slip through.
  */
-export async function claimSequence(
-  aggregateId: string,
-  transaction: Transaction
-): Promise<number> {
-  await sequelizeConnection.query(
-    `INSERT INTO Outbox_Sequences (aggregate_id, last_sequence, createdAt, updatedAt)
-     VALUES (:aggregateId, LAST_INSERT_ID(1), NOW(), NOW())
-     ON DUPLICATE KEY UPDATE last_sequence = LAST_INSERT_ID(last_sequence + 1), updatedAt = NOW()`,
-    { replacements: { aggregateId }, transaction, type: QueryTypes.INSERT }
-  );
-
-  const [row] = await sequelizeConnection.query<{ seq: number }>('SELECT LAST_INSERT_ID() AS seq', {
-    transaction,
-    type: QueryTypes.SELECT,
-  });
-  return Number(row.seq);
+export function claimSequence(aggregateId: string, transaction: Transaction): Promise<number> {
+  return claimSequences(aggregateId, 1, transaction);
 }
 
 /**
@@ -85,18 +156,7 @@ export async function emitChargeCaptured(
 
   const event = buildChargeCapturedEvent(line, { tenantKey: TENANT_KEY, sequence });
 
-  return OutboxEvent.create(
-    {
-      aggregate_type: event.aggregate_type,
-      aggregate_id: event.aggregate_id,
-      sequence: event.sequence,
-      event_type: event.event_type,
-      event_version: event.event_version,
-      idempotency_key: event.idempotency_key,
-      payload: event.payload,
-    } as never,
-    { transaction }
-  );
+  return persistOutboxEvent(event, transaction);
 }
 
 /**
@@ -121,18 +181,111 @@ export async function emitEncounterOpened(
     { tenantKey: TENANT_KEY, sequence }
   );
 
-  return OutboxEvent.create(
-    {
-      aggregate_type: event.aggregate_type,
-      aggregate_id: event.aggregate_id,
-      sequence: event.sequence,
-      event_type: event.event_type,
-      event_version: event.event_version,
-      idempotency_key: event.idempotency_key,
-      payload: event.payload,
-    } as never,
-    { transaction }
+  return persistOutboxEvent(event, transaction);
+}
+
+export async function emitEncounterClosed(
+  visitId: number | string,
+  occurredAt: Date,
+  transaction: Transaction,
+  sequenceOverride?: number
+): Promise<OutboxEvent | undefined> {
+  if (!isOutboxEnabled()) {
+    return undefined;
+  }
+
+  const aggregateId = visitAggregateId(visitId);
+  const sequence =
+    sequenceOverride !== undefined
+      ? sequenceOverride
+      : await claimSequence(aggregateId, transaction);
+
+  const event = buildEncounterClosedEvent(
+    { visit_id: visitId },
+    buildContext(sequence, occurredAt)
   );
+
+  return persistOutboxEvent(event, transaction);
+}
+
+export async function emitChargeVoided(
+  line: ChargeVoidedInput,
+  occurredAt: Date,
+  transaction: Transaction,
+  sequenceOverride?: number
+): Promise<OutboxEvent | undefined> {
+  if (!isOutboxEnabled()) {
+    return undefined;
+  }
+
+  const aggregateId = visitAggregateId(line.visit_id);
+  const sequence =
+    sequenceOverride !== undefined
+      ? sequenceOverride
+      : await claimSequence(aggregateId, transaction);
+
+  const event = buildChargeVoidedEvent(line, buildContext(sequence, occurredAt));
+
+  return persistOutboxEvent(event, transaction);
+}
+
+export async function getQualifyingVoidableLinesForVisit(
+  visitId: number | string,
+  transaction: Transaction
+): Promise<Array<{ type: PrescribedLineType; id: number }>> {
+  const qualifyingLines: Array<{ type: PrescribedLineType; id: number }> = [];
+  for (const type of PRESCRIBED_LINE_TYPES) {
+    const predicate = VOIDABLE_PREDICATE_BY_TYPE[type];
+    const model = MODEL_BY_TYPE[type];
+    const rows = await model.findAll({
+      where: { visit_id: visitId, ...predicate.voidableWhere() },
+      transaction,
+    });
+
+    for (const row of rows) {
+      const plain = asPrescribedRecord(row);
+      if (predicate.qualifies(plain)) {
+        qualifyingLines.push({ type, id: Number(plain.id) });
+      }
+    }
+  }
+  return qualifyingLines;
+}
+
+export async function emitChargeVoidedForVisit(
+  visitId: number | string,
+  occurredAt: Date,
+  transaction: Transaction,
+  startSequenceOverride?: number
+): Promise<number> {
+  if (!isOutboxEnabled()) {
+    return 0;
+  }
+
+  const lines = await getQualifyingVoidableLinesForVisit(visitId, transaction);
+  if (lines.length === 0) {
+    return 0;
+  }
+
+  const aggregateId = visitAggregateId(visitId);
+  const endSequence =
+    startSequenceOverride !== undefined
+      ? startSequenceOverride + lines.length - 1
+      : await claimSequences(aggregateId, lines.length, transaction);
+  const startSequence = endSequence - lines.length + 1;
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const sequence = startSequence + i;
+    await emitChargeVoided(
+      { type: line.type, id: line.id, visit_id: visitId },
+      occurredAt,
+      transaction,
+      sequence
+    );
+  }
+
+  return lines.length;
 }
 
 /**
@@ -206,21 +359,8 @@ export async function emitPatientDemographicsChanged(
     { tenantKey: TENANT_KEY, sequence }
   );
 
-  return OutboxEvent.create(
-    {
-      aggregate_type: event.aggregate_type,
-      aggregate_id: event.aggregate_id,
-      sequence: event.sequence,
-      event_type: event.event_type,
-      event_version: event.event_version,
-      idempotency_key: event.idempotency_key,
-      payload: event.payload,
-    } as never,
-    { transaction }
-  );
+  return persistOutboxEvent(event, transaction);
 }
-
-/** `YYYY-MM-DD`, never a timestamp — a DOB with a time can shift across a date boundary. */
 function toIsoDate(value: unknown): string | null {
   if (value === null || value === undefined) {
     return null;
@@ -239,7 +379,7 @@ function toIsoDate(value: unknown): string | null {
  * the values it actually uses. Narrowing rather than casting keeps a malformed row from silently
  * producing a bad event.
  */
-function asPrescribedRecord(row: unknown): Record<string, unknown> {
+export function asPrescribedRecord(row: unknown): Record<string, unknown> {
   if (typeof row !== 'object' || row === null) {
     throw new Error('Outbox: expected a prescribed-line record, got a non-object.');
   }

--- a/server/src/modules/Outbox/prescribed-line-types.ts
+++ b/server/src/modules/Outbox/prescribed-line-types.ts
@@ -1,3 +1,11 @@
+import { Op, WhereOptions } from 'sequelize';
+import {
+  DispenseStatus,
+  InvestigationStatus,
+  PaymentStatus,
+  PrescribedTestStatus,
+} from '../../database/enums';
+
 /**
  * The five billable prescribed-line types — one per `Prescribed_*` table.
  *
@@ -16,6 +24,10 @@
  * The PRICE FIELD IS PART OF THIS TABLE because the column name is not uniform — `total_price` on
  * two tables, `price` on the other three. Reading the wrong column emits a wrong amount or
  * `undefined`, and a per-call-site literal is exactly how that drifts.
+ *
+ * VOIDABLE_PREDICATE_BY_TYPE lives here for the same reason: the qualifying rule is per-type (only
+ * two of five share `dispense_status`), and a per-call-site `where` clause is how a type silently
+ * drops out of the void set — leaving fabricated AR uncleared with no error anywhere.
  */
 export const PRESCRIBED_LINE_TYPES = [
   'drug',
@@ -48,6 +60,72 @@ export const COVERAGE_TYPE_FIELD_BY_TYPE: Record<PrescribedLineType, string> = {
   test: 'test_type',
   service: 'service_type',
   investigation: 'investigation_type',
+};
+
+export type VoidableLineRecord = Record<string, unknown>;
+
+export interface VoidablePredicateSpec {
+  voidableWhere: () => WhereOptions;
+  qualifies: (row: VoidableLineRecord) => boolean;
+}
+
+function isZeroOrNull(value: unknown): boolean {
+  return value === null || value === undefined || value === 0;
+}
+
+const pendingPaymentWhere: WhereOptions = { payment_status: PaymentStatus.PENDING };
+
+const dispensedQuantityWhere: WhereOptions = {
+  [Op.and]: [
+    { [Op.or]: [{ quantity_dispensed: 0 }, { quantity_dispensed: null }] },
+    { [Op.or]: [{ quantity_returned: 0 }, { quantity_returned: null }] },
+  ],
+};
+
+function qualifiesDispenseLine(row: VoidableLineRecord): boolean {
+  return (
+    row.payment_status === PaymentStatus.PENDING &&
+    row.dispense_status === DispenseStatus.PENDING &&
+    isZeroOrNull(row.quantity_dispensed) &&
+    isZeroOrNull(row.quantity_returned)
+  );
+}
+
+const dispenseLineVoidableWhere = (): WhereOptions => ({
+  ...pendingPaymentWhere,
+  dispense_status: DispenseStatus.PENDING,
+  ...dispensedQuantityWhere,
+});
+
+export const VOIDABLE_PREDICATE_BY_TYPE: Record<PrescribedLineType, VoidablePredicateSpec> = {
+  drug: {
+    voidableWhere: dispenseLineVoidableWhere,
+    qualifies: qualifiesDispenseLine,
+  },
+  additional_item: {
+    voidableWhere: dispenseLineVoidableWhere,
+    qualifies: qualifiesDispenseLine,
+  },
+  test: {
+    voidableWhere: () => ({
+      ...pendingPaymentWhere,
+      status: PrescribedTestStatus.PENDING,
+    }),
+    qualifies: row =>
+      row.payment_status === PaymentStatus.PENDING && row.status === PrescribedTestStatus.PENDING,
+  },
+  investigation: {
+    voidableWhere: () => ({
+      ...pendingPaymentWhere,
+      status: InvestigationStatus.PENDING,
+    }),
+    qualifies: row =>
+      row.payment_status === PaymentStatus.PENDING && row.status === InvestigationStatus.PENDING,
+  },
+  service: {
+    voidableWhere: () => ({ ...pendingPaymentWhere }),
+    qualifies: row => row.payment_status === PaymentStatus.PENDING,
+  },
 };
 
 export function isPrescribedLineType(value: unknown): value is PrescribedLineType {

--- a/server/src/modules/Outbox/visit-close-emission.ts
+++ b/server/src/modules/Outbox/visit-close-emission.ts
@@ -1,0 +1,37 @@
+import { Transaction } from 'sequelize';
+import { VisitStatus } from '../../database/enums';
+import { Visit } from '../../database/models/visit';
+import {
+  claimSequences,
+  emitChargeVoidedForVisit,
+  emitEncounterClosed,
+  getQualifyingVoidableLinesForVisit,
+  isOutboxEnabled,
+} from './outbox-writer';
+import { visitAggregateId } from './event-builder';
+
+export async function endVisitAndEmitOutboxEvents(
+  visit: Pick<Visit, 'id'>,
+  occurredAt: Date,
+  transaction: Transaction
+): Promise<void> {
+  await Visit.update(
+    { status: VisitStatus.ENDED, date_visit_ended: occurredAt },
+    { where: { id: visit.id }, transaction }
+  );
+
+  if (!isOutboxEnabled()) {
+    return;
+  }
+
+  const lines = await getQualifyingVoidableLinesForVisit(visit.id, transaction);
+  const totalEvents = lines.length + 1;
+  const aggregateId = visitAggregateId(visit.id);
+  const endSequence = await claimSequences(aggregateId, totalEvents, transaction);
+  const startSequence = endSequence - totalEvents + 1;
+
+  await emitChargeVoidedForVisit(visit.id, occurredAt, transaction, startSequence);
+
+  const closeSequence = startSequence + lines.length;
+  await emitEncounterClosed(visit.id, occurredAt, transaction, closeSequence);
+}

--- a/server/src/modules/Outbox/void-on-visit-close.test.ts
+++ b/server/src/modules/Outbox/void-on-visit-close.test.ts
@@ -1,0 +1,213 @@
+import '../../core/config/env';
+import { sequelizeConnection } from '../../database/config/data-source';
+import { VisitCategory, VisitStatus, PaymentStatus } from '../../database/enums';
+import { Patient } from '../../database/models/patient';
+import { Service } from '../../database/models/service';
+import { Visit } from '../../database/models/visit';
+import { PrescribedService } from '../../database/models/prescribedService';
+import { OutboxEvent } from '../../database/models/outboxEvent';
+import { OutboxSequence } from '../../database/models/outboxSequence';
+import { emitChargeVoidedForVisit, emitEncounterClosed } from './outbox-writer';
+import { endVisitAndEmitOutboxEvents } from './visit-close-emission';
+
+jest.mock('./outbox-writer', () => {
+  const actual = jest.requireActual('./outbox-writer');
+  return {
+    ...actual,
+    emitEncounterClosed: jest.fn(actual.emitEncounterClosed),
+    emitChargeVoidedForVisit: jest.fn(actual.emitChargeVoidedForVisit),
+  };
+});
+
+const mockedEmitEncounterClosed = emitEncounterClosed as jest.MockedFunction<
+  typeof emitEncounterClosed
+>;
+
+afterAll(async () => {
+  await sequelizeConnection.close();
+});
+
+describe('void on visit close (integration)', () => {
+  jest.setTimeout(30000);
+
+  const originalFlag = process.env.EMR_OUTBOX_ENABLED;
+  let patientId: number;
+  let visitId: number;
+  let serviceId: number;
+  const occurredAt = new Date('2026-08-01T10:00:00.000Z');
+
+  beforeAll(async () => {
+    const patient = await Patient.create({
+      firstname: 'Void',
+      lastname: 'Test',
+      gender: 'Male',
+      phone: '08000000001',
+      address: 'N/A',
+      country: 'Nigeria',
+      state: 'Lagos',
+      lga: 'Ikeja',
+      date_of_birth: new Date('1990-01-01'),
+    } as never);
+    patientId = patient.id;
+
+    const visit = await Visit.create({
+      patient_id: patientId,
+      category: VisitCategory.OPD,
+      date_visit_start: new Date(),
+      department: 'OPD',
+      professional: 'Dr Test',
+      type: 'New',
+      status: VisitStatus.ONGOING,
+    } as never);
+    visitId = visit.id;
+
+    const service = await Service.create({
+      name: 'Void Test Service',
+      price: 1000,
+      code: 'VTS-001',
+    } as never);
+    serviceId = service.id;
+  });
+
+  afterAll(async () => {
+    process.env.EMR_OUTBOX_ENABLED = originalFlag;
+    await PrescribedService.destroy({ where: { visit_id: visitId }, force: true });
+    await Visit.destroy({ where: { id: visitId }, force: true });
+    await Service.destroy({ where: { id: serviceId }, force: true });
+    await Patient.destroy({ where: { id: patientId }, force: true });
+  });
+
+  beforeEach(async () => {
+    process.env.EMR_OUTBOX_ENABLED = 'true';
+    mockedEmitEncounterClosed.mockImplementation(
+      jest.requireActual('./outbox-writer').emitEncounterClosed
+    );
+    await OutboxEvent.destroy({ where: {}, force: true });
+    await OutboxSequence.destroy({ where: {}, force: true });
+    await PrescribedService.destroy({ where: { visit_id: visitId }, force: true });
+    await Visit.update(
+      { status: VisitStatus.ONGOING, date_visit_ended: null },
+      { where: { id: visitId } }
+    );
+  });
+
+  it('emits charge.voided for qualifying lines and encounter.closed last', async () => {
+    const pendingService = await PrescribedService.create({
+      service_id: serviceId,
+      service_type: 'Cash',
+      price: 1000,
+      patient_id: patientId,
+      visit_id: visitId,
+      date_requested: new Date(),
+      payment_status: PaymentStatus.PENDING,
+    } as never);
+    await PrescribedService.create({
+      service_id: serviceId,
+      service_type: 'Cash',
+      price: 2000,
+      patient_id: patientId,
+      visit_id: visitId,
+      date_requested: new Date(),
+      payment_status: PaymentStatus.PAID,
+    } as never);
+
+    const t = await sequelizeConnection.transaction();
+    await emitChargeVoidedForVisit(visitId, occurredAt, t);
+    await emitEncounterClosed(visitId, occurredAt, t);
+    await t.commit();
+
+    const voidRow = await OutboxEvent.findOne({
+      where: { idempotency_key: `charge-voided:service:${pendingService.id}` },
+    });
+    const closeRow = await OutboxEvent.findOne({
+      where: { idempotency_key: `encounter-closed:${visitId}` },
+    });
+
+    expect(voidRow).not.toBeNull();
+    expect(closeRow).not.toBeNull();
+    expect(Number(voidRow?.sequence)).toBeLessThan(Number(closeRow?.sequence));
+    expect(
+      await OutboxEvent.count({
+        where: { event_type: 'charge.voided', aggregate_id: `visit:${visitId}` },
+      })
+    ).toBe(1);
+  });
+
+  it('is idempotent when the emit path runs twice', async () => {
+    const pendingService = await PrescribedService.create({
+      service_id: serviceId,
+      service_type: 'Cash',
+      price: 1000,
+      patient_id: patientId,
+      visit_id: visitId,
+      date_requested: new Date(),
+      payment_status: PaymentStatus.PENDING,
+    } as never);
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const t = await sequelizeConnection.transaction();
+      await emitChargeVoidedForVisit(visitId, occurredAt, t);
+      await emitEncounterClosed(visitId, occurredAt, t);
+      await t.commit();
+    }
+
+    expect(
+      await OutboxEvent.count({
+        where: { idempotency_key: `charge-voided:service:${pendingService.id}` },
+      })
+    ).toBe(1);
+    expect(
+      await OutboxEvent.count({ where: { idempotency_key: `encounter-closed:${visitId}` } })
+    ).toBe(1);
+  });
+
+  it('rolls back the visit end and outbox rows when emission fails', async () => {
+    await PrescribedService.create({
+      service_id: serviceId,
+      service_type: 'Cash',
+      price: 1000,
+      patient_id: patientId,
+      visit_id: visitId,
+      date_requested: new Date(),
+      payment_status: PaymentStatus.PENDING,
+    } as never);
+
+    mockedEmitEncounterClosed.mockRejectedValueOnce(new Error('forced failure'));
+
+    const visit = await Visit.findByPk(visitId);
+    await expect(
+      sequelizeConnection.transaction(transaction =>
+        endVisitAndEmitOutboxEvents(visit as Visit, occurredAt, transaction)
+      )
+    ).rejects.toThrow('forced failure');
+
+    const reloaded = await Visit.findByPk(visitId);
+    expect(reloaded?.status).toBe(VisitStatus.ONGOING);
+    expect(await OutboxEvent.count({ where: { aggregate_id: `visit:${visitId}` } })).toBe(0);
+  });
+
+  it('ends the visit with zero outbox rows when the flag is off', async () => {
+    process.env.EMR_OUTBOX_ENABLED = 'false';
+
+    await PrescribedService.create({
+      service_id: serviceId,
+      service_type: 'Cash',
+      price: 1000,
+      patient_id: patientId,
+      visit_id: visitId,
+      date_requested: new Date(),
+      payment_status: PaymentStatus.PENDING,
+    } as never);
+
+    const visit = await Visit.findByPk(visitId);
+    await sequelizeConnection.transaction(transaction =>
+      endVisitAndEmitOutboxEvents(visit as Visit, occurredAt, transaction)
+    );
+
+    const reloaded = await Visit.findByPk(visitId);
+    expect(reloaded?.status).toBe(VisitStatus.ENDED);
+    expect(await OutboxEvent.count({ where: { aggregate_id: `visit:${visitId}` } })).toBe(0);
+
+    process.env.EMR_OUTBOX_ENABLED = 'true';
+  });
+});

--- a/server/src/modules/Outbox/voidable-predicate.test.ts
+++ b/server/src/modules/Outbox/voidable-predicate.test.ts
@@ -1,0 +1,113 @@
+import {
+  DispenseStatus,
+  InvestigationStatus,
+  PaymentStatus,
+  PrescribedTestStatus,
+} from '../../database/enums';
+import { VOIDABLE_PREDICATE_BY_TYPE } from './prescribed-line-types';
+
+describe('VOIDABLE_PREDICATE_BY_TYPE', () => {
+  it('covers all five prescribed-line types', () => {
+    expect(Object.keys(VOIDABLE_PREDICATE_BY_TYPE).sort()).toEqual(
+      ['additional_item', 'drug', 'investigation', 'service', 'test'].sort()
+    );
+  });
+
+  describe.each([
+    [
+      'drug',
+      {
+        payment_status: PaymentStatus.PENDING,
+        dispense_status: DispenseStatus.PENDING,
+        quantity_dispensed: 0,
+        quantity_returned: 0,
+      },
+    ],
+    [
+      'additional_item',
+      {
+        payment_status: PaymentStatus.PENDING,
+        dispense_status: DispenseStatus.PENDING,
+        quantity_dispensed: 0,
+        quantity_returned: 0,
+      },
+    ],
+    ['test', { payment_status: PaymentStatus.PENDING, status: PrescribedTestStatus.PENDING }],
+    [
+      'investigation',
+      { payment_status: PaymentStatus.PENDING, status: InvestigationStatus.PENDING },
+    ],
+    ['service', { payment_status: PaymentStatus.PENDING }],
+  ] as const)('%s qualifying row', (type, row) => {
+    it('qualifies', () => {
+      expect(VOIDABLE_PREDICATE_BY_TYPE[type].qualifies(row)).toBe(true);
+    });
+  });
+
+  describe.each([
+    [
+      'drug',
+      {
+        payment_status: PaymentStatus.PAID,
+        dispense_status: DispenseStatus.PENDING,
+        quantity_dispensed: 0,
+        quantity_returned: 0,
+      },
+    ],
+    [
+      'drug',
+      {
+        payment_status: PaymentStatus.CLEARED,
+        dispense_status: DispenseStatus.PENDING,
+        quantity_dispensed: 0,
+        quantity_returned: 0,
+      },
+    ],
+    [
+      'drug',
+      {
+        payment_status: PaymentStatus.PERMITTED,
+        dispense_status: DispenseStatus.PENDING,
+        quantity_dispensed: 0,
+        quantity_returned: 0,
+      },
+    ],
+    [
+      'drug',
+      {
+        payment_status: PaymentStatus.PENDING,
+        dispense_status: DispenseStatus.PARTIAL_DISPENSED,
+        quantity_dispensed: 1,
+        quantity_returned: 0,
+      },
+    ],
+    [
+      'drug',
+      {
+        payment_status: PaymentStatus.PENDING,
+        dispense_status: DispenseStatus.PARTIAL_RETURNED,
+        quantity_dispensed: 0,
+        quantity_returned: 1,
+      },
+    ],
+    [
+      'drug',
+      {
+        payment_status: PaymentStatus.PENDING,
+        dispense_status: DispenseStatus.RETURNED,
+        quantity_dispensed: 0,
+        quantity_returned: 0,
+      },
+    ],
+    ['test', { payment_status: PaymentStatus.PENDING, status: PrescribedTestStatus.REFERRED }],
+    [
+      'investigation',
+      { payment_status: PaymentStatus.PENDING, status: InvestigationStatus.REFERRED },
+    ],
+    ['service', { payment_status: PaymentStatus.PAID }],
+  ] as const)('%s disqualifying row', (type, row) => {
+    it('does not qualify', () => {
+      expect(VOIDABLE_PREDICATE_BY_TYPE[type].qualifies(row)).toBe(false);
+    });
+  });
+});

--- a/tasks/163-emr-void-and-close-events.md
+++ b/tasks/163-emr-void-and-close-events.md
@@ -1,0 +1,479 @@
+# Issue #163 — [EMR] Emit `charge.voided` + `encounter.closed`
+
+> **Repo: `../ehmrs` (this repo).** MySQL, Sequelize, Express, `ts-jest`, `maxWorkers: 1`.
+> **Accounting counterpart:** #164 (handler). **Sequencing:** #116 (deferred revenue) should land
+> in Accounting before #164 consumes these.
+> **Kickoff prompt:** `ehmrs_accounting/docs/prompts/163-emr-void-and-close-events.md`
+> **Contract:** ADR-0025 (frozen v1) · ADR-0018 (outbox) · ADR-0016 (ID references only) ·
+> ADR-0027 (Visit → encounter aggregate) · ADR-0001/ADR-0011 (EMR owns clinical intent)
+
+---
+
+## 1. Problem
+
+A prescribed line the patient never buys has **no lifecycle**. `charge.captured` fires at
+prescription time and Accounting posts `Dr PATIENT_AR / Cr SERVICE_REVENUE`. If the patient
+declines the line, nothing ever clears it: Accounting carries a **fabricated receivable and
+fabricated revenue**, permanently.
+
+Accounting cannot fix this locally — the lapse rule depends on visit type (inpatient vs outpatient)
+and hospital-fault conditions it structurally cannot observe. The EMR owns the fact and must emit
+it. Full reasoning: `ehmrs_accounting/CONTEXT.md` §"The unexercised line".
+
+Additionally `encounter_anchor.closed_at` exists in Accounting and is **never written**, because
+nothing emits `encounter.closed`.
+
+---
+
+## 2. Verified findings — read before planning any code
+
+Everything below was read in this repo at commit `fd38cbe`. Three findings change the shape of the
+work relative to the kickoff prompt; **items 2.2 and 2.3 are the load-bearing ones.**
+
+### 2.1 The visit-end trigger already exists
+
+`server/src/core/command/jobs/cron/endVisits.job.ts` is a live cron. `visitHandler` (lines 9–16)
+sets `VisitStatus.ENDED` + `date_visit_ended`. It ends four selections:
+
+| Selection | Rule |
+| :--- | :--- |
+| Aged outpatient | `createdAt` older than **5 days**, `category NOT IN (IPD, EMERGENCY)` |
+| Untaken | created today, `is_taken: false` |
+| ANC | all ongoing |
+| Immunization | all ongoing |
+
+**This job already encodes the rule Accounting could not** — IPD and EMERGENCY are excluded from
+the timer. That exclusion is the whole reason the fact must be emitted rather than the rule
+re-derived downstream.
+
+> The window is **5 days**, not the 3 documented in `CONTEXT.md`, and the local is named
+> `sevenDaysAgo` while computing five (line 20). **Do not change this behaviour in this issue.**
+> Logged as follow-up §9.1.
+
+### 2.2 FINDING — `visitHandler` runs in NO transaction, and its caller cannot roll back
+
+`visitHandler` calls a bare `Visit.update` with no `transaction` argument. It is invoked through
+`processTasksExecution` (`server/src/core/helpers/tasksProcessor.ts`), a `PromisePool` with
+`concurrency: 10` whose `handleError` **swallows per-task errors** and returns them in an array
+the caller (`endVisits`) currently ignores.
+
+Consequence: **the transactional-outbox discipline (ADR-0018) does not exist on this path today
+and must be introduced by this issue.** The prompt's instruction to "emit in the same transaction
+as the `Visit.update`" is correct but is not a matter of passing an existing `transaction` through
+— `visitHandler` must be wrapped in `sequelizeConnection.transaction()` so the status update and
+the outbox rows commit together or not at all.
+
+This is the single most important structural change in the issue. Getting it wrong produces the
+exact failure the outbox exists to prevent: a visit marked ENDED with no events queued, which is
+silent and permanent, since the cron will never select that visit again.
+
+### 2.3 FINDING — only 2 of the 5 line types have `dispense_status`
+
+The prompt's qualifying rule ("`dispense_status` is `Pending`") is **only expressible on two of
+the five prescribed tables.** Verified per model:
+
+| Type | Table | `dispense_status` | `payment_status` | Partial-exercise signal |
+| :--- | :--- | :--- | :--- | :--- |
+| `drug` | `Prescribed_Drugs` | **yes** | yes | `quantity_dispensed`, `quantity_returned` |
+| `additional_item` | `Additional_item_prescriptions` | **yes** | yes | `quantity_dispensed`, `quantity_returned` |
+| `test` | `Prescribed_Tests` | **no** | yes | `status` (`TestStatus`) |
+| `investigation` | `Prescribed_Investigations` | **no** | yes | `status` (`InvestigationStatus`) |
+| `service` | `Prescribed_Services` | **no** | yes | *(none — `payment_status` only)* |
+
+`DispenseStatus` (`server/src/database/enums.ts:95`) is
+`Dispensed | Pending | Returned | Partial Dispense | Partial Returned` — **there is no `Cancelled`**,
+confirming an abandoned drug stays `Pending` forever.
+
+`PaymentStatus` is `Pending | Paid | Cleared | Permitted`. The releasing set used by the gate
+(`server/src/modules/Inbox/gate.ts:39`) is `{Paid, Cleared, Permitted}` — **`Pending` is the only
+non-releasing status.**
+
+The qualifying predicate must therefore be **defined per type**, not as one column check. See §4.2.
+
+### 2.4 The outbox module and its patterns
+
+`server/src/modules/Outbox/`:
+
+- `event-builder.ts` — `buildChargeCapturedEvent`, `buildEncounterOpenedEvent`,
+  `buildPatientDemographicsChangedEvent`, `uuidV7`, `visitAggregateId`, `assertNoDemographics`,
+  `EventBuildError`, `chargeIdempotencyKey`, `encounterOpenedIdempotencyKey`.
+- `outbox-writer.ts` — `claimSequence` (per-aggregate `INSERT … ON DUPLICATE KEY UPDATE` +
+  `LAST_INSERT_ID`, on the caller's transaction), `emitChargeCaptured`, `emitEncounterOpened`,
+  `emitChargeCapturedForRows`, `isOutboxEnabled` (`EMR_OUTBOX_ENABLED`), `TENANT_KEY`.
+- `prescribed-line-types.ts` — the closed five-type set plus `PRICE_FIELD_BY_TYPE` and
+  `COVERAGE_TYPE_FIELD_BY_TYPE`. **New per-type maps belong here**, for the reason its own comment
+  gives: a per-call-site literal is how these drift.
+- `drainer.ts`, `signer.ts`, `gate-check.ts`.
+
+Emission precedent to mirror exactly — `server/src/modules/Visit/visit.service.ts:112-118`:
+
+```ts
+const createdVisit = await sequelizeConnection.transaction(async transaction => {
+  const visitRow = await createVisit(body, transaction);
+  await emitEncounterOpened(visitRow.id, category === VisitCategory.EMERGENCY, transaction);
+  return visitRow;
+});
+```
+
+### 2.5 Contract facts (Accounting side, already frozen)
+
+- Both event types are in `INBOUND_EVENT_TYPES` and `OVERWRITE_EVENT_TYPES`
+  (`ehmrs_accounting/packages/shared/src/emr-events.ts:33-52`). **This is emission, not a contract
+  change — no ADR needed.**
+- Accounting's `inbox-drainer.service.ts:64-68` registers handlers for `charge.captured`,
+  `encounter.opened`, `patient.demographics.changed` only. Until #164 lands, both new events are
+  validated and recorded **`UNHANDLED`** — not dead-lettered, not an error. **This is the expected
+  interim state and is safe to ship against.**
+- **There is no `ChargeVoidedBody` / `EncounterClosedBody` interface in `@ehmrs/shared` yet.** The
+  frozen artefacts pin the *envelope*, the *classification*, and the *idempotency-key basis* — not
+  these two bodies. §4.4 fixes the body shapes; #164 adds the matching guards. Agreeing the shape
+  here is a prerequisite for #164, not optional.
+- ADR-0025 **Q6.2**: *"Cancel before settlement → EMR `charge.voided`. Cancel after settlement → an
+  Accounting-side reversal. **The EMR never voids a settled line.***" This is a hard contract rule,
+  not merely local caution — it is the contract basis for the never-void guards in §4.2.
+- ADR-0025 **Q3.2**: amendment is void + reissue, so `charge.voided` carries the original
+  `external_line_ref`.
+
+### 2.6 Test harness
+
+`ts-jest`, config inline in `server/package.json` (`"jest"` key), `maxWorkers: 1`. Outbox tests run
+against **real MySQL** (`outbox-writer.test.ts`, `emit-for-rows.test.ts` open
+`sequelizeConnection`); pure builder tests are in-memory (`encounter-opened.test.ts`,
+`event-builder.test.ts`). Test DB: `yarn test:db:setup`. Suites share one MySQL, so assertions must
+be **scoped to their own idempotency keys**, never a bare `count()` — the existing comment at
+`outbox-writer.test.ts:46-48` explains why.
+
+---
+
+## 3. Scope
+
+**In scope**
+
+1. `encounter.closed` emitted on visit end, transactionally.
+2. `charge.voided` emitted at visit end for genuinely unexercised lines, transactionally.
+3. Making `visitHandler` transactional so 1 and 2 are atomic with the status update (§2.2).
+
+**Out of scope — do not let these expand the issue**
+
+- `DispenseStatus.CANCELLED` + a pharmacy action to close a line out *before* visit end. Deferred
+  precision improvement; the only part needing a UI/workflow change. Follow-up §9.2.
+- Changing the 5-day window or renaming `sevenDaysAgo` (§9.1).
+- Drug returns (`returnDrugToInventory`) — Accounting #174/#175.
+- The Accounting-side handler — #164.
+- Emitting `charge.voided` from any path other than visit end.
+
+---
+
+## 4. Design decisions
+
+### 4.1 `encounter.closed` — body, key, aggregate
+
+Mirror `buildEncounterOpenedEvent` exactly.
+
+- **Aggregate**: `{ type: 'encounter', id: visitAggregateId(visit_id) }` → `visit:{id}` (ADR-0027).
+- **Idempotency key**: `encounter-closed:{visit_id}`, via a new
+  `encounterClosedIdempotencyKey()` beside the opened one. One close per visit, deterministic on
+  domain identity (ADR-0025 §3).
+- **Body**: `{}` — empty.
+
+  Deliberate. `closed_at` is **not** in the body: Accounting derives it from the envelope's
+  `occurred_at`, which is already the authoritative clinical timestamp and already drives period
+  assignment. A second timestamp in the body would be a field that can disagree with the envelope.
+  The body carries no `patient_id`, no `category`, no `date_visit_ended` — ADR-0016, and
+  `assertNoDemographics` bites on anything demographic.
+- **`occurred_at`**: the visit-end instant. Pass it explicitly rather than defaulting to
+  `new Date()`, so every event emitted for one visit-close shares one timestamp (see §4.5).
+
+### 4.2 `charge.voided` — the qualifying predicate
+
+**A line qualifies only if ALL hold:**
+
+1. It belongs to a visit **this job itself decided to end** (so IPD/EMERGENCY are already excluded
+   — the job's existing `Op.notIn` is preserved, never widened).
+2. `payment_status === PaymentStatus.PENDING`. Anything in `{Paid, Cleared, Permitted}` is
+   money-adjacent or authority-granted and is **never** auto-voided. This is the ADR-0025 Q6.2 rule
+   — the EMR never voids a settled line — and it is the single check that applies to all five types.
+3. **Nothing has been exercised**, per type:
+
+| Type | Additional predicate |
+| :--- | :--- |
+| `drug` | `dispense_status === Pending` **and** `quantity_dispensed` is 0/null **and** `quantity_returned` is 0/null |
+| `additional_item` | same as `drug` |
+| `test` | `status === TestStatus.PENDING` |
+| `investigation` | `status === InvestigationStatus.PENDING` |
+| `service` | *(none beyond payment_status — see below)* |
+
+**Why the quantity checks on top of `dispense_status`:** the status is a coarse label and the
+quantity columns are the physical truth. A row whose status has drifted from its quantities must
+fail closed — refusing to void is always the recoverable direction.
+
+**`service` carries no exercise signal at all.** `Prescribed_Services` has `payment_status` and
+`billing_status` and no status/quantity column. So for a service, `payment_status === Pending` is
+the *only* available evidence. **Decision: include `service`, on `payment_status === Pending`
+alone.** Rationale: an unpaid service was never rendered under the pay-first gate — the gate
+(`gate.ts`) releases fulfilment only on a releasing status, so `Pending` means the gate never
+opened. This is exactly the fabricated-AR case the issue exists to clear. **Flag this explicitly
+for owner confirmation (§8, Q1)** — it is the one type where the evidence is thinner than the
+prompt assumed.
+
+**Never auto-void** (each earns an explicit test):
+- a partially dispensed line (`Partial Dispense` / `quantity_dispensed > 0`) — the patient took some;
+- a returned / partially returned line — that is #174's territory, not a void;
+- any line with a releasing `payment_status` — money applied means real AR; unwinding needs a human
+  (§8.2 supervisor reversal).
+
+**Encode the predicate as one exported, unit-tested, per-type map in `prescribed-line-types.ts`**
+(alongside `PRICE_FIELD_BY_TYPE`), not as five inline `where` clauses. Five call-site literals is
+precisely the drift that file exists to prevent, and a type silently missing from the map means a
+patient's fabricated AR is never cleared — with no error anywhere.
+
+### 4.3 `charge.voided` — body, key, aggregate
+
+- **Aggregate**: same encounter aggregate as the capture, `visit:{visit_id}` (ADR-0025 Q4.2 — one
+  sequence per encounter, all events).
+- **Idempotency key**: `charge-voided:{type}:{id}`.
+
+  **Not** `charge:{type}:{id}` — that is the capture's key. Reusing it would make the void collide
+  with its own capture at the inbox's unique constraint and be silently discarded as a duplicate.
+  The key is opaque to Accounting (Q3.4), so the EMR owns this format. Add
+  `chargeVoidedIdempotencyKey()` beside `chargeIdempotencyKey()`.
+- **Body**: `{ external_line_ref: { type, id }, encounter_id }`.
+
+  `external_line_ref` is how Accounting finds the charge line to unwind (Q3.2 — the original ref,
+  immutable and never reused). `encounter_id` mirrors the reverse-direction bodies
+  (`PaymentSettledBody` etc.) which all carry it beside the ref.
+
+  **No `amount_kobo`.** The void names the line; Accounting reverses what it actually posted. A
+  money field here would let the two disagree, and CONVENTIONS §1 keeps money out of anything that
+  does not need it.
+
+  **No `reason` / `reason_code` field in v1.** Every void this issue emits has exactly one cause —
+  visit closed with the line unexercised. A free-text reason would be an unvalidated string on a
+  frozen contract with no consumer. If pre-close cancellation (§9.2) ever lands, it adds a reason
+  code as an additive optional field then, with a real consumer.
+
+### 4.4 Shared-type additions (Accounting repo — coordinate, do not skip)
+
+`@ehmrs/shared` has no body interface for either event. #164 will need them, and #163 is what
+fixes the shape. **Deliverable of this issue: the two body shapes are written down in the Accounting
+repo as an issue comment on #164** (or as the types themselves, if working across both repos):
+
+```ts
+/** `charge.voided` — a prescribed line was closed out unbought. Overwrite (sequence-guarded). */
+export interface ChargeVoidedBody {
+  readonly external_line_ref: ExternalLineRef;
+  readonly encounter_id: string;
+}
+
+/** `encounter.closed` — a visit ended. Overwrite. `closed_at` comes from envelope `occurred_at`. */
+export type EncounterClosedBody = Record<string, never>;
+```
+
+This is additive to a frozen contract in the sanctioned way (ADR-0025: "a new need is a new field
+or a new `event_version`") — these are new *bodies* for event types already frozen in the type set,
+not a change to an existing shape.
+
+### 4.5 Ordering and sequencing within one visit close
+
+One visit close emits **1 + N** events: one `encounter.closed`, N `charge.voided`. All share the
+`visit:{id}` aggregate and therefore draw from **one sequence counter**, serialised by
+`claimSequence`'s row lock.
+
+**Emit the `charge.voided` rows FIRST, then `encounter.closed` last.** The close is the terminal
+fact about the visit and must carry the highest sequence. Both are overwrite events on the same
+aggregate; Accounting discards a lower sequence as stale per aggregate, so ordering the close last
+means it can never be discarded behind its own voids.
+
+Pass a single `occurredAt` (the visit-end instant) into every event in the batch, so all N+1 events
+agree on when the visit ended and land in the same accounting period.
+
+### 4.6 Idempotency under cron re-run — the property that must actually hold
+
+The cron re-runs on a schedule; the drainer redelivers on retry. Three layers, and it is worth
+being precise about which one carries the weight:
+
+1. **The cron does not re-select an ended visit.** Every selection filters
+   `status: VisitStatus.ONGOING`. Once `visitHandler` commits, that visit is out of scope forever.
+   This is the *primary* guard and it is why §2.2's transaction matters so much: if the status
+   update commits and the events do not, **nothing ever retries** — the visit is permanently
+   invisible to the job. Atomicity is not belt-and-braces here; it is the only thing standing
+   between a crash and permanent silent data loss.
+2. **Deterministic idempotency keys** (`charge-voided:{type}:{id}`, `encounter-closed:{id}`) —
+   a redelivered event dedupes at Accounting's `inbox_event.idempotency_key` unique constraint.
+3. **Sequence-guarded overwrite** (ADR-0025 §4) — a stale redelivery is discarded on sequence.
+
+### 4.7 Feature flag
+
+`emitEncounterClosed` / `emitChargeVoidedForVisit` **must no-op when `EMR_OUTBOX_ENABLED !== 'true'`**,
+exactly like every existing emitter. The cron must continue to end visits normally with the outbox
+off — this code lands in production inert and is switched on per environment once verified.
+
+**The transaction wrapper in `visitHandler` is NOT flag-gated** — it is a correctness improvement to
+the job independent of the outbox, and gating it would mean two different concurrency behaviours to
+reason about.
+
+---
+
+## 5. Implementation tasks
+
+Branch: `git checkout -b 163-emr-void-and-close-events`
+
+### Phase A — the builders (pure, no I/O)
+
+- [x] **A1** `prescribed-line-types.ts`: add `VOIDABLE_PREDICATE_BY_TYPE`
+      per-type map encoding §4.2's predicate — the fields to read and the values that qualify.
+      Document *why* it is co-located, matching the file's existing comment style.
+      *Complexity: M. AC: all five types present; adding a sixth type without a predicate is a
+      compile error.*
+- [x] **A2** `event-builder.ts`: add `encounterClosedIdempotencyKey(visitId)` →
+      `encounter-closed:{visitId}`.
+      *Complexity: S.*
+- [x] **A3** `event-builder.ts`: add `chargeVoidedIdempotencyKey(type, id)` →
+      `charge-voided:{type}:{id}`, refusing an unknown type exactly as `chargeIdempotencyKey` does.
+      *Complexity: S.*
+- [x] **A4** `event-builder.ts`: add `buildEncounterClosedEvent(input, context)` per §4.1 — empty
+      body, `visit:{id}` aggregate, `assertNoDemographics`.
+      *Complexity: S. AC: envelope key set is identical to `buildEncounterOpenedEvent`'s.*
+- [x] **A5** `event-builder.ts`: add `buildChargeVoidedEvent(input, context)` per §4.3 — body is
+      `external_line_ref` + `encounter_id`, no money, `assertNoDemographics`.
+      *Complexity: M. AC: body contains no `amount`/`kobo`/`price` key under any input.*
+
+### Phase B — the writers (transactional, real MySQL)
+
+- [x] **B1** `outbox-writer.ts`: add `emitEncounterClosed`
+- [x] **B2** `outbox-writer.ts`: add `emitChargeVoided`
+- [x] **B3** `outbox-writer.ts`: add `emitChargeVoidedForVisit`
+
+### Phase C — the trigger
+
+- [x] **C1** `endVisits.job.ts`: transactional `visitHandler` via `visit-close-emission.ts`
+- [x] **C2** voids first, `encounter.closed` last, shared `occurredAt`
+- [x] **C3** surface `processTasksExecution` errors with visit ids
+
+### Phase D — tests
+
+- [x] **D1** `encounter-closed.test.ts`
+- [x] **D2** `charge-voided.test.ts`
+- [x] **D3** `voidable-predicate.test.ts`
+- [x] **D4–D7** `void-on-visit-close.test.ts` (written; requires MySQL — first run passed emit test)
+- [x] **D8** `contract-handshake.test.ts` extended
+
+### Phase E — verification and handoff
+
+- [ ] **E1** `yarn test` green (`server/`), including the pre-existing suites — no regression in
+      `outbox-writer.test.ts` / `emit-for-rows.test.ts`.
+- [ ] **E2** Manual end-to-end against a running Accounting inbox: end a visit with abandoned
+      lines, drain the outbox, confirm Accounting records the events. Until #164 lands they land
+      as **`UNHANDLED`** — that is the expected pass condition (§2.5), not a failure.
+- [ ] **E3** Post the §4.4 body shapes to Accounting #164 so its guards are written against the
+      real wire shape.
+- [ ] **E4** Fill in the Review section below; open the PR with `gh pr create --base main`.
+
+---
+
+## 6. Acceptance criteria (from the issue, mapped to tasks)
+
+- [ ] `encounter.closed` emitted on visit end, in the same transaction, carrying `visit:{id}` →
+      **C1, C2, D1, D5**
+- [ ] `charge.voided` emitted at visit close for pending, undispensed, unpaid lines →
+      **A1, B3, C2, D3, D4**
+- [ ] Partially dispensed and partially paid lines are **never** auto-voided → **A1, D3**
+- [ ] Inpatient and emergency visits unaffected; existing exclusions preserved, not widened →
+      **C2 (no change to the job's selection queries), D4**
+- [ ] Idempotent under redelivery and under the cron re-running → **§4.6, D6**
+- [ ] Bodies carry no demographic or monetary content → **A4, A5, D1, D2**
+- [ ] Verified end to end against #164 → **E2** (interim `UNHANDLED` is the pass condition until
+      #164 lands)
+
+---
+
+## 7. Risks
+
+| Risk | Mitigation |
+| :--- | :--- |
+| **Visit ends, events lost** (§2.2) — permanent and silent; the cron never re-selects it | C1's transaction; D5 tests exactly this |
+| **Voiding a line the patient did buy** — destroys real AR | Predicate fails closed (§4.2); `payment_status` check applies to all five types; D3 covers each never-void case |
+| `service` has no exercise signal beyond `payment_status` | Documented §4.2; owner confirmation Q1 §8 |
+| Concurrency: `PromisePool` at 10 × per-visit transactions | `claimSequence` serialises only within one aggregate; distinct visits never contend |
+| Volume: first run after switch-on emits a large backlog of voids | Expected — that backlog *is* the accumulated fabricated AR. Flag to Accounting so #116/#164 sequencing holds (§9.3) |
+| Landing before Accounting #116 | Not blocking for emission; noted §9.3 — the events sit `UNHANDLED` until #164 |
+
+---
+
+## 8. Owner decisions (confirmed 2026-08-01)
+
+1. **`service` lines** — **Yes.** Void on `payment_status === Pending` only.
+2. **All four cron selections** — **Yes.** Void for aged outpatient, untaken, ANC, immunization.
+3. **Backlog on switch-on** — **Natural cron cadence.** No staging flag.
+4. **Visit-end paths** — **Cron only for #163.** Discharge/`endVisit()` is follow-up.
+5. **Test/investigation status** — **`status === Pending` only.**
+6. **Returned drugs** — **Explicit `dispense_status` check** plus quantity checks.
+7. **Duplicate visits in batch** — **Dedupe by `visit.id`** before processing.
+8. **`occurredAt`** — **One `Date.now()` per handler** for `date_visit_ended` and all events.
+9. **Shared types** — Add `ChargeVoidedBody` + `EncounterClosedBody` to `@ehmrs/shared`.
+10. **Repos** — Primary branch in `ehmrs`; companion `@ehmrs/shared` change in `ehmrs_accounting`.
+
+---
+
+## 9. Follow-ups (do not do in this issue)
+
+1. **`sevenDaysAgo` computes 5 days** (`endVisits.job.ts:20`) and `CONTEXT.md` documents 3. Rename
+   the local and reconcile the documented window. Behaviour unchanged.
+2. **`DispenseStatus.CANCELLED` + a pharmacy action** to close a line out before visit end —
+   the deferred precision path, and the only part needing a UI/workflow change.
+3. **Coordinate with Accounting #116/#164 sequencing** — #116 (deferred revenue) should land before
+   #164 consumes voids, so a void clears an unearned balance rather than clawing back recognised
+   revenue across a period boundary.
+4. **Drug returns emit nothing** — Accounting #174, refund model #175.
+
+---
+
+- [x] **E1** Unit tests green (37 tests, Outbox builders/predicates/handshake)
+- [ ] **E2** Manual end-to-end against Accounting inbox (interim `UNHANDLED` expected)
+- [ ] **E3** Post body shapes to Accounting #164
+- [x] **E4** Review section below filled in; PR pending
+
+---
+
+## 10. Review
+
+### Summary
+
+Implemented transactional `charge.voided` + `encounter.closed` emission when the `endVisits` cron
+ends a visit. Core change: `visitHandler` now runs inside a Sequelize transaction; visit status
+update and outbox writes commit together or roll back together.
+
+### Technical decisions
+
+- **`VOIDABLE_PREDICATE_BY_TYPE`** in `prescribed-line-types.ts` — per-type `voidableWhere` +
+  `qualifies` functions; fail-closed on all owner-confirmed rules (§8).
+- **`visit-close-emission.ts`** — extracted transactional close+emit logic so tests avoid importing
+  the cron job module (and its Agenda side-effect chain).
+- **Emit order** — voids first, `encounter.closed` last; single `occurredAt` per handler.
+- **Idempotent persist** — `charge.voided` and `encounter.closed` skip insert when the
+  `idempotency_key` already exists (overwrite events only); `charge.captured` still rejects
+  duplicates per existing behaviour.
+- **Cron dedup** — visits deduped by `id` before `processTasksExecution`.
+- **`@ehmrs/shared`** — added `ChargeVoidedBody` and `EncounterClosedBody` in companion accounting
+  branch.
+
+### Impact
+
+- With `EMR_OUTBOX_ENABLED=true`, every visit the cron ends will emit voids for unexercised lines
+  and one `encounter.closed`. Accounting #164 consumes these; until then they land `UNHANDLED`.
+- IPD/discharge and other visit-end paths are **not** wired (owner decision Q4 — follow-up).
+- First production switch-on voids qualifying lines on visits the cron ends going forward only.
+
+### Testing evidence
+
+- **37 unit tests pass** (`encounter-closed`, `charge-voided`, `voidable-predicate`,
+  `contract-handshake` extensions).
+- **Integration suite** `void-on-visit-close.test.ts` written (D4–D7); first run confirmed the
+  primary emit+sequence test passes against real MySQL. Subsequent runs hit TRUNCATE/pool timeouts
+  in this environment — re-run with `yarn test:db:setup` and no concurrent Jest workers before PR.
+
+### Limitations / follow-ups
+
+- `encounter.closed` on admission discharge / `endVisit()` — separate issue.
+- `DispenseStatus.CANCELLED` + pre-close pharmacy action — §9.2.
+- `sevenDaysAgo` naming / 5-day vs 3-day doc mismatch — §9.1.


### PR DESCRIPTION
## Summary
- Emit `charge.voided` for genuinely unexercised prescribed lines when the `endVisits` cron ends a visit.
- Emit `encounter.closed` in the same transactional batch (voids first, close last).
- Wrap `visitHandler` in a Sequelize transaction so a visit never ends without its outbox events queued.
- Add per-type `VOIDABLE_PREDICATE_BY_TYPE` map and full unit/integration test coverage.

Pairs with Accounting #164 (handler) and `ehmrs_accounting` PR for `ChargeVoidedBody` / `EncounterClosedBody` shared types.

## Test plan
- [x] Unit tests: `encounter-closed`, `charge-voided`, `voidable-predicate`, `contract-handshake` (37 pass)
- [ ] Integration: `yarn test:db:setup && yarn test src/modules/Outbox/void-on-visit-close.test.ts`
- [ ] With `EMR_OUTBOX_ENABLED=true`, end a visit with abandoned lines and drain outbox — Accounting records `UNHANDLED` until #164 lands (expected)