### PR TITLE
feat(outbox): charge.reversal.requested on prescribe-line delete (Accounting #14)

### DIFF
--- a/server/src/modules/Orders/Laboratory/lab-order.repository.ts
+++ b/server/src/modules/Orders/Laboratory/lab-order.repository.ts
@@ -7,7 +7,10 @@ import { BadException } from '../../../common/util/api-error';
 import { StatusCodes } from '../../../core/helpers/helper';
 import { ERROR_UPDATING_TEST } from './messages/response-messages';
 import { sequelizeConnection } from '../../../database/config/data-source';
-import { emitChargeCapturedForRows } from '../../Outbox/outbox-writer';
+import {
+  emitChargeCapturedForRows,
+  deletePrescribedLineWithReversalRequested,
+} from '../../Outbox/outbox-writer';
 
 /**
  * prescribe a test for patient
@@ -123,5 +126,10 @@ export const getOnePrescribedTest = async (query: WhereOptions<PrescribedTest>) 
  * @param testId
  */
 export const deletePrescribedTest = async (testId: number) => {
-  return PrescribedTest.destroy({ where: { id: testId } });
+  return deletePrescribedLineWithReversalRequested(
+    'test',
+    testId,
+    transaction => PrescribedTest.findOne({ where: { id: testId }, transaction }),
+    transaction => PrescribedTest.destroy({ where: { id: testId }, transaction })
+  );
 };

--- a/server/src/modules/Orders/Pharmacy/pharmacy-order.repository.ts
+++ b/server/src/modules/Orders/Pharmacy/pharmacy-order.repository.ts
@@ -35,7 +35,10 @@ import {
 } from './messages/response-messages';
 import { sequelizeConnection } from '../../../database/config/data-source';
 import { getPatientInsuranceQuery } from '../../Insurance/insurance.repository';
-import { emitChargeCapturedForRows } from '../../Outbox/outbox-writer';
+import {
+  emitChargeCapturedForRows,
+  deletePrescribedLineWithReversalRequested,
+} from '../../Outbox/outbox-writer';
 
 type PrescribeDrugType = PrescribedDrugBody & {
   drug_prescription_id: number;
@@ -914,7 +917,12 @@ export const getPatientTreatments = ({ currentPage = 1, pageLimit = 10, filter =
  * @param drugId
  */
 export const deletePrescribedDrug = async (drugId: number) => {
-  return PrescribedDrug.destroy({ where: { id: drugId } });
+  return deletePrescribedLineWithReversalRequested(
+    'drug',
+    drugId,
+    transaction => PrescribedDrug.findOne({ where: { id: drugId }, transaction }),
+    transaction => PrescribedDrug.destroy({ where: { id: drugId }, transaction })
+  );
 };
 
 /**
@@ -922,7 +930,12 @@ export const deletePrescribedDrug = async (drugId: number) => {
  * @param itemId
  */
 export const deleteAdditionalItem = async (itemId: number) => {
-  return PrescribedAdditionalItem.destroy({ where: { id: itemId } });
+  return deletePrescribedLineWithReversalRequested(
+    'additional_item',
+    itemId,
+    transaction => PrescribedAdditionalItem.findOne({ where: { id: itemId }, transaction }),
+    transaction => PrescribedAdditionalItem.destroy({ where: { id: itemId }, transaction })
+  );
 };
 
 /**

--- a/server/src/modules/Orders/Radiology/radiology-order.repository.ts
+++ b/server/src/modules/Orders/Radiology/radiology-order.repository.ts
@@ -14,7 +14,10 @@ import { ERROR_UPDATING_INVESTIGATION, HSG_ITEMS_MISSING } from './messages/resp
 import dayjs from 'dayjs';
 import { sequelizeConnection } from '../../../database/config/data-source';
 import { getOneDefault } from '../../AdminSettings/admin.repository';
-import { emitChargeCapturedForRows } from '../../Outbox/outbox-writer';
+import {
+  emitChargeCapturedForRows,
+  deletePrescribedLineWithReversalRequested,
+} from '../../Outbox/outbox-writer';
 import { DefaultType, DrugForm, PharmacyDrugType } from '../../../database/enums';
 import { NHISApprovalStatus } from '../../../core/helpers/general';
 import { getDrugPrice } from '../../Pharmacy/pharmacy.repository';
@@ -313,5 +316,10 @@ export const getOnePrescribedInvestigation = async (
  * @param investigationId
  */
 export const deletePrescribedInvestigation = async (investigationId: number) => {
-  return PrescribedInvestigation.destroy({ where: { id: investigationId } });
+  return deletePrescribedLineWithReversalRequested(
+    'investigation',
+    investigationId,
+    transaction => PrescribedInvestigation.findOne({ where: { id: investigationId }, transaction }),
+    transaction => PrescribedInvestigation.destroy({ where: { id: investigationId }, transaction })
+  );
 };

--- a/server/src/modules/Orders/Service/service-order.repository.ts
+++ b/server/src/modules/Orders/Service/service-order.repository.ts
@@ -8,7 +8,10 @@ import { StatusCodes } from '../../../core/helpers/helper';
 import { BadException } from '../../../common/util/api-error';
 import { ERROR_UPDATING_SERVICE } from './messages/response-messages';
 import { sequelizeConnection } from '../../../database/config/data-source';
-import { emitChargeCapturedForRows } from '../../Outbox/outbox-writer';
+import {
+  emitChargeCapturedForRows,
+  deletePrescribedLineWithReversalRequested,
+} from '../../Outbox/outbox-writer';
 
 /**
  * prescribe multiple services for patient
@@ -148,5 +151,10 @@ export const getOnePrescribedService = async (
  * @param serviceId
  */
 export const deleteService = async serviceId => {
-  return PrescribedService.destroy({ where: { id: serviceId } });
+  return deletePrescribedLineWithReversalRequested(
+    'service',
+    serviceId,
+    transaction => PrescribedService.findOne({ where: { id: serviceId }, transaction }),
+    transaction => PrescribedService.destroy({ where: { id: serviceId }, transaction })
+  );
 };

--- a/server/src/modules/Outbox/charge-reversal-requested.test.ts
+++ b/server/src/modules/Outbox/charge-reversal-requested.test.ts
@@ -1,0 +1,69 @@
+import {
+  EventBuildError,
+  buildChargeReversalRequestedEvent,
+  chargeIdempotencyKey,
+  chargeReversalRequestedIdempotencyKey,
+} from './event-builder';
+
+const context = {
+  tenantKey: 'lagoon_general',
+  sequence: 8,
+  occurredAt: new Date('2026-07-26T11:00:00.000Z'),
+  sentAt: new Date('2026-07-26T11:00:01.000Z'),
+};
+
+describe('chargeReversalRequestedIdempotencyKey', () => {
+  it('is deterministic and distinct from capture and void keys', () => {
+    expect(chargeReversalRequestedIdempotencyKey('drug', 42)).toBe('reversal_requested:drug:42');
+    expect(chargeReversalRequestedIdempotencyKey('drug', 42)).not.toBe(
+      chargeIdempotencyKey('drug', 42)
+    );
+  });
+
+  it('refuses an unknown type', () => {
+    expect(() => chargeReversalRequestedIdempotencyKey('unknown' as never, 1)).toThrow(
+      EventBuildError
+    );
+  });
+});
+
+describe('buildChargeReversalRequestedEvent', () => {
+  it('carries external_line_ref and encounter_id only when reason is omitted', () => {
+    const row = buildChargeReversalRequestedEvent(
+      { type: 'drug', id: 42, visit_id: 8891 },
+      context
+    );
+
+    expect(row.event_type).toBe('charge.reversal.requested');
+    expect(row.payload.body).toEqual({
+      external_line_ref: { type: 'drug', id: '42' },
+      encounter_id: 'visit:8891',
+    });
+  });
+
+  it('includes optional reason when supplied', () => {
+    const row = buildChargeReversalRequestedEvent(
+      { type: 'service', id: 9, visit_id: 8891, reason: 'WRONG_PATIENT' },
+      context
+    );
+    expect(row.payload.body).toEqual({
+      external_line_ref: { type: 'service', id: '9' },
+      encounter_id: 'visit:8891',
+      reason: 'WRONG_PATIENT',
+    });
+  });
+
+  it('carries no money field under any input', () => {
+    const row = buildChargeReversalRequestedEvent(
+      { type: 'service', id: 9, visit_id: 8891 },
+      context
+    );
+    const body = row.payload.body as Record<string, unknown>;
+    const keys = Object.keys(body);
+
+    expect(keys).not.toContain('amount_kobo');
+    expect(keys).not.toContain('amount');
+    expect(keys).not.toContain('price');
+    expect(keys).not.toContain('kobo');
+  });
+});

--- a/server/src/modules/Outbox/contract-handshake.test.ts
+++ b/server/src/modules/Outbox/contract-handshake.test.ts
@@ -1,6 +1,7 @@
 import { createHash, createHmac } from 'crypto';
 import {
   buildChargeCapturedEvent,
+  buildChargeReversalRequestedEvent,
   buildChargeVoidedEvent,
   buildEncounterClosedEvent,
   buildPatientDemographicsChangedEvent,
@@ -179,6 +180,18 @@ describe('EMR outbox ↔ Accounting inbox handshake', () => {
     const row = buildChargeVoidedEvent(
       { type: 'drug', id: 42, visit_id: 8891 },
       { tenantKey: TENANT_KEY, sequence: 43 }
+    );
+    const signed = signEvent(row.payload, SHARED_KEY);
+    expect(verifyLikeAccounting(Buffer.from(signed.rawBody), signed.headers)).toEqual({
+      ok: true,
+      keyId: SHARED_KEY.keyId,
+    });
+  });
+
+  it('a signed charge.reversal.requested is ACCEPTED by the verifier', () => {
+    const row = buildChargeReversalRequestedEvent(
+      { type: 'drug', id: 42, visit_id: 8891, reason: 'WRONG_PATIENT' },
+      { tenantKey: TENANT_KEY, sequence: 45 }
     );
     const signed = signEvent(row.payload, SHARED_KEY);
     expect(verifyLikeAccounting(Buffer.from(signed.rawBody), signed.headers)).toEqual({

--- a/server/src/modules/Outbox/emit-for-rows.test.ts
+++ b/server/src/modules/Outbox/emit-for-rows.test.ts
@@ -6,6 +6,8 @@ import { Insurance } from '../../database/models/insurance';
 import { HMO } from '../../database/models/hmo';
 import { PatientInsurance } from '../../database/models/patientInsurance';
 import { Patient } from '../../database/models/patient';
+import { Visit } from '../../database/models/visit';
+import { VisitCategory } from '../../database/enums';
 import { emitChargeCapturedForRows, normalisePrice } from './outbox-writer';
 
 afterAll(async () => {
@@ -205,6 +207,7 @@ describe('emitChargeCapturedForRows — payer derivation (#114)', () => {
 
   afterAll(async () => {
     process.env.EMR_OUTBOX_ENABLED = originalFlag;
+    await Visit.destroy({ where: { patient_id: patientId }, force: true });
     await PatientInsurance.destroy({
       where: { id: [schemePatientInsuranceId, retainerPatientInsuranceId] },
       force: true,
@@ -372,5 +375,117 @@ describe('emitChargeCapturedForRows — payer derivation (#114)', () => {
     // The COMPLETE insurance set: Accounting hard-deletes anything absent from this array, so a
     // partial list would silently drop the patient's live coverage.
     expect(body.insurances).toHaveLength(2);
+  });
+
+  describe('visit metadata emission (#192)', () => {
+    it('attaches visit_type and consultation_valid_until for an OPD visit', async () => {
+      const visit = await Visit.create({
+        patient_id: patientId,
+        category: VisitCategory.OPD,
+        date_visit_start: new Date('2026-08-04T12:00:00.000Z'),
+        department: 'GOPD',
+        professional: 'Doctor',
+        type: 'New',
+      } as never);
+
+      const t = await sequelizeConnection.transaction();
+      await emitChargeCapturedForRows(
+        'drug',
+        [
+          {
+            id: 95,
+            patient_id: patientId,
+            visit_id: visit.id,
+            total_price: '100.00',
+            quantity_prescribed: 1,
+          },
+        ],
+        '2026-08-04',
+        t
+      );
+      await t.commit();
+
+      const events = await OutboxEvent.findAll();
+      const charge = events.find(row => row.event_type === 'charge.captured');
+      expect(charge).toBeDefined();
+      const body = charge!.payload.body as Record<string, unknown>;
+      expect(body.visit_type).toBe('Outpatient');
+      expect(body.consultation_valid_until).toBe('2026-08-09T12:00:00.000Z'); // start + 5 days
+    });
+
+    it('attaches visit_type and omits consultation_valid_until for an ongoing IPD visit', async () => {
+      const visit = await Visit.create({
+        patient_id: patientId,
+        category: VisitCategory.IPD,
+        date_visit_start: new Date('2026-08-04T12:00:00.000Z'),
+        department: 'Ward A',
+        professional: 'Doctor',
+        type: 'Admission',
+      } as never);
+
+      const t = await sequelizeConnection.transaction();
+      await emitChargeCapturedForRows(
+        'drug',
+        [
+          {
+            id: 96,
+            patient_id: patientId,
+            visit_id: visit.id,
+            total_price: '100.00',
+            quantity_prescribed: 1,
+          },
+        ],
+        '2026-08-04',
+        t
+      );
+      await t.commit();
+
+      const events = await OutboxEvent.findAll();
+      const charge = events.find(
+        row => row.event_type === 'charge.captured' && row.idempotency_key === 'charge:drug:96'
+      );
+      expect(charge).toBeDefined();
+      const body = charge!.payload.body as Record<string, unknown>;
+      expect(body.visit_type).toBe('Inpatient');
+      expect('consultation_valid_until' in body).toBe(false);
+    });
+
+    it('attaches visit_type and consultation_valid_until (as date_visit_ended) for a closed IPD visit', async () => {
+      const visit = await Visit.create({
+        patient_id: patientId,
+        category: VisitCategory.IPD,
+        date_visit_start: new Date('2026-08-04T12:00:00.000Z'),
+        date_visit_ended: new Date('2026-08-05T15:00:00.000Z'),
+        department: 'Ward A',
+        professional: 'Doctor',
+        type: 'Admission',
+      } as never);
+
+      const t = await sequelizeConnection.transaction();
+      await emitChargeCapturedForRows(
+        'drug',
+        [
+          {
+            id: 97,
+            patient_id: patientId,
+            visit_id: visit.id,
+            total_price: '100.00',
+            quantity_prescribed: 1,
+          },
+        ],
+        '2026-08-04',
+        t
+      );
+      await t.commit();
+
+      const events = await OutboxEvent.findAll();
+      const charge = events.find(
+        row => row.event_type === 'charge.captured' && row.idempotency_key === 'charge:drug:97'
+      );
+      expect(charge).toBeDefined();
+      const body = charge!.payload.body as Record<string, unknown>;
+      expect(body.visit_type).toBe('Inpatient');
+      expect(body.consultation_valid_until).toBe('2026-08-05T15:00:00.000Z');
+    });
   });
 });

--- a/server/src/modules/Outbox/event-builder.test.ts
+++ b/server/src/modules/Outbox/event-builder.test.ts
@@ -184,6 +184,27 @@ describe('buildChargeCapturedEvent', () => {
     const payer = (row.payload.body as Record<string, unknown>).payer as Record<string, unknown>;
     expect(payer.retainership_id).toBe('42');
   });
+
+  it('omits visit_type and consultation_valid_until when the line carries none (backward-compat)', () => {
+    const row = buildChargeCapturedEvent(baseLine, context);
+    const body = row.payload.body as Record<string, unknown>;
+    expect('visit_type' in body).toBe(false);
+    expect('consultation_valid_until' in body).toBe(false);
+  });
+
+  it('emits visit_type and consultation_valid_until when provided', () => {
+    const row = buildChargeCapturedEvent(
+      {
+        ...baseLine,
+        visit_type: 'Outpatient',
+        consultation_valid_until: '2026-08-04T12:00:00Z',
+      },
+      context
+    );
+    const body = row.payload.body as Record<string, unknown>;
+    expect(body.visit_type).toBe('Outpatient');
+    expect(body.consultation_valid_until).toBe('2026-08-04T12:00:00Z');
+  });
 });
 
 describe('patientAggregateId', () => {

--- a/server/src/modules/Outbox/event-builder.ts
+++ b/server/src/modules/Outbox/event-builder.ts
@@ -108,6 +108,8 @@ export interface PrescribedLineInput {
   readonly service_line?: string;
   /** Payer at prescription time (ADR-0028). Omitted for cash lines; ID references only. */
   readonly payer?: ChargeCapturedPayer;
+  readonly visit_type?: string;
+  readonly consultation_valid_until?: string;
 }
 
 export interface BuildContext {
@@ -256,6 +258,12 @@ export function buildChargeCapturedEvent(
   }
   if (line.payer !== undefined) {
     body.payer = buildPayer(line.payer);
+  }
+  if (line.visit_type !== undefined) {
+    body.visit_type = line.visit_type;
+  }
+  if (line.consultation_valid_until !== undefined) {
+    body.consultation_valid_until = line.consultation_valid_until;
   }
 
   assertNoDemographics(body, 'charge.captured');

--- a/server/src/modules/Outbox/event-builder.ts
+++ b/server/src/modules/Outbox/event-builder.ts
@@ -208,6 +208,18 @@ export function chargeVoidedIdempotencyKey(type: PrescribedLineType, id: number 
   return `charge-voided:${type}:${id}`;
 }
 
+export function chargeReversalRequestedIdempotencyKey(
+  type: PrescribedLineType,
+  id: number | string
+): string {
+  if (!isPrescribedLineType(type)) {
+    throw new EventBuildError(
+      `Unknown prescribed-line type "${type}"; expected one of ${PRESCRIBED_LINE_TYPES.join(', ')}`
+    );
+  }
+  return `reversal_requested:${type}:${id}`;
+}
+
 export interface OutboxEventRow {
   readonly aggregate_type: string;
   readonly aggregate_id: string;
@@ -315,6 +327,13 @@ export interface ChargeVoidedInput {
   readonly visit_id: number | string;
 }
 
+export interface ChargeReversalRequestedInput {
+  readonly type: PrescribedLineType;
+  readonly id: number | string;
+  readonly visit_id: number | string;
+  readonly reason?: string;
+}
+
 export function buildEncounterClosedEvent(
   input: EncounterClosedInput,
   context: BuildContext
@@ -396,6 +415,58 @@ export function buildChargeVoidedEvent(
     aggregate_id: encounterId,
     sequence: context.sequence,
     event_type: 'charge.voided',
+    event_version: eventVersion,
+    idempotency_key: idempotencyKey,
+    payload,
+  };
+}
+
+export function buildChargeReversalRequestedEvent(
+  input: ChargeReversalRequestedInput,
+  context: BuildContext
+): OutboxEventRow {
+  if (!isPrescribedLineType(input.type)) {
+    throw new EventBuildError(
+      `Unknown prescribed-line type "${input.type}"; expected one of ${PRESCRIBED_LINE_TYPES.join(
+        ', '
+      )}`
+    );
+  }
+
+  const encounterId = visitAggregateId(input.visit_id);
+  const occurredAt = context.occurredAt ?? new Date();
+  const sentAt = context.sentAt ?? new Date();
+  const idempotencyKey = chargeReversalRequestedIdempotencyKey(input.type, input.id);
+  const eventVersion = context.eventVersion ?? 1;
+
+  const body: Record<string, unknown> = {
+    external_line_ref: { type: input.type, id: String(input.id) },
+    encounter_id: encounterId,
+  };
+  if (input.reason !== undefined) {
+    body.reason = input.reason;
+  }
+
+  assertNoDemographics(body, 'charge.reversal.requested');
+
+  const payload: Record<string, unknown> = {
+    event_id: uuidV7(context.now),
+    event_type: 'charge.reversal.requested',
+    event_version: eventVersion,
+    tenant_key: context.tenantKey,
+    occurred_at: occurredAt.toISOString(),
+    sent_at: sentAt.toISOString(),
+    aggregate: { type: 'encounter', id: encounterId },
+    sequence: Number(context.sequence),
+    idempotency_key: idempotencyKey,
+    body,
+  };
+
+  return {
+    aggregate_type: 'encounter',
+    aggregate_id: encounterId,
+    sequence: context.sequence,
+    event_type: 'charge.reversal.requested',
     event_version: eventVersion,
     idempotency_key: idempotencyKey,
     payload,

--- a/server/src/modules/Outbox/outbox-writer.ts
+++ b/server/src/modules/Outbox/outbox-writer.ts
@@ -18,6 +18,7 @@ import { VisitCategory } from '../../database/enums';
 import dayjs from 'dayjs';
 import {
   buildChargeCapturedEvent,
+  buildChargeReversalRequestedEvent,
   buildChargeVoidedEvent,
   buildEncounterClosedEvent,
   buildEncounterOpenedEvent,
@@ -25,6 +26,7 @@ import {
   patientAggregateId,
   visitAggregateId,
   PrescribedLineInput,
+  ChargeReversalRequestedInput,
   ChargeVoidedInput,
 } from './event-builder';
 import {
@@ -235,6 +237,48 @@ export async function emitChargeVoided(
   const event = buildChargeVoidedEvent(line, buildContext(sequence, occurredAt));
 
   return persistOutboxEvent(event, transaction);
+}
+
+export async function emitChargeReversalRequested(
+  line: ChargeReversalRequestedInput,
+  transaction: Transaction
+): Promise<OutboxEvent | undefined> {
+  if (!isOutboxEnabled()) {
+    return undefined;
+  }
+
+  const aggregateId = visitAggregateId(line.visit_id);
+  const sequence = await claimSequence(aggregateId, transaction);
+
+  const event = buildChargeReversalRequestedEvent(line, {
+    tenantKey: TENANT_KEY,
+    sequence,
+  });
+
+  return persistOutboxEvent(event, transaction);
+}
+
+export async function deletePrescribedLineWithReversalRequested(
+  type: PrescribedLineType,
+  lineId: number,
+  findLine: (transaction: Transaction) => Promise<{ id: number; visit_id: number | string } | null>,
+  destroyLine: (transaction: Transaction) => Promise<number>
+): Promise<number> {
+  return sequelizeConnection.transaction(async transaction => {
+    const line = await findLine(transaction);
+    if (!line) {
+      return 0;
+    }
+
+    if (isOutboxEnabled()) {
+      await emitChargeReversalRequested(
+        { type, id: line.id, visit_id: line.visit_id },
+        transaction
+      );
+    }
+
+    return destroyLine(transaction);
+  });
 }
 
 export async function getQualifyingVoidableLinesForVisit(
@@ -542,7 +586,6 @@ export async function emitChargeCapturedForRows(
 
     await emitChargeCaptured(input, transaction);
 
-    // Emit demographics for new patients only (deduplicated per call)
     const patientKey = String(patientId);
     if (!processedPatients.has(patientKey)) {
       processedPatients.add(patientKey);

--- a/server/src/modules/Outbox/outbox-writer.ts
+++ b/server/src/modules/Outbox/outbox-writer.ts
@@ -13,6 +13,9 @@ import { Drug } from '../../database/models/drug';
 import { Test } from '../../database/models/test';
 import { Investigation } from '../../database/models/investigation';
 import { Service } from '../../database/models/service';
+import { Visit } from '../../database/models/visit';
+import { VisitCategory } from '../../database/enums';
+import dayjs from 'dayjs';
 import {
   buildChargeCapturedEvent,
   buildChargeVoidedEvent,
@@ -433,6 +436,60 @@ export function normalisePrice(value: unknown): unknown {
   return value.toFixed(2);
 }
 
+export class VisitResolver {
+  private readonly cache = new Map<
+    number,
+    { visit_type: string; consultation_valid_until?: string } | null
+  >();
+
+  constructor(private readonly transaction: Transaction) {}
+
+  async resolve(
+    visitId: unknown
+  ): Promise<{ visit_type: string; consultation_valid_until?: string } | null> {
+    const id = Number(visitId);
+    if (!Number.isInteger(id)) {
+      return null;
+    }
+
+    if (this.cache.has(id)) {
+      const cached = this.cache.get(id);
+      return cached !== undefined ? cached : null;
+    }
+
+    const visit = await Visit.findOne({
+      where: { id },
+      attributes: ['id', 'category', 'date_visit_start', 'date_visit_ended'],
+      transaction: this.transaction,
+    });
+
+    if (!visit) {
+      this.cache.set(id, null);
+      return null;
+    }
+
+    const visitType = visit.category;
+    const result: { visit_type: string; consultation_valid_until?: string } = {
+      visit_type: visitType,
+    };
+
+    if (visit.category === VisitCategory.IPD || visit.category === VisitCategory.EMERGENCY) {
+      if (visit.date_visit_ended) {
+        result.consultation_valid_until = dayjs(visit.date_visit_ended).toISOString();
+      }
+    } else {
+      if (visit.date_visit_start) {
+        result.consultation_valid_until = dayjs(visit.date_visit_start)
+          .add(5, 'days')
+          .toISOString();
+      }
+    }
+
+    this.cache.set(id, result);
+    return result;
+  }
+}
+
 /**
  * Emits a charge.captured for each row a prescribe endpoint created, on its transaction.
  *
@@ -454,6 +511,7 @@ export async function emitChargeCapturedForRows(
   const priceField = PRICE_FIELD_BY_TYPE[type];
   const coverageField = COVERAGE_TYPE_FIELD_BY_TYPE[type];
   const payerResolver = new PayerResolver(transaction);
+  const visitResolver = new VisitResolver(transaction);
   const processedPatients = new Set<string>();
 
   const serviceLineResolver = createServiceLineResolver(type, transaction);
@@ -462,9 +520,10 @@ export async function emitChargeCapturedForRows(
     const row = asPrescribedRecord(raw);
     const patientId = Number(row.patient_id);
 
-    const [payer, serviceLine] = await Promise.all([
+    const [payer, serviceLine, visitInfo] = await Promise.all([
       payerResolver.resolve(row.patient_insurance_id, row[coverageField]),
       serviceLineResolver(row),
+      visitResolver.resolve(row.visit_id),
     ]);
 
     const input: PrescribedLineInput = {
@@ -477,6 +536,8 @@ export async function emitChargeCapturedForRows(
       service_date: serviceDate,
       payer,
       service_line: serviceLine,
+      visit_type: visitInfo?.visit_type,
+      consultation_valid_until: visitInfo?.consultation_valid_until,
     };
 
     await emitChargeCaptured(input, transaction);

--- a/tasks/192-emr-emit-visit-metadata.md
+++ b/tasks/192-emr-emit-visit-metadata.md
@@ -1,0 +1,48 @@
+# Task Plan — Issue #192: Emit EMR Visit Metadata on `charge.captured`
+
+**Status:** COMPLETED. Branch: `192-emit-visit-metadata` in `ehmrs` repository.
+
+## 0. Context & Invariants
+
+This issue implements the EMR-side emission of the visit metadata fields (`visit_type` and `consultation_valid_until`) on the `charge.captured` event body.
+This is the emission side of the rollout:
+`EMR (#192) emits` → `Accounting (#193) ingests` → `Accounting (#194) returns` → `Client (#68) renders`.
+
+* **Governing ADRs:** **0031** (visit metadata rides on `charge.captured`) · **0016** (no demographics on transactions; ID-only references) · **0025** (frozen v1 envelope shape but additive evolution).
+* **CONVENTIONS:** Money as integer kobo string, no demographic leakage, backward-compatible layout (fields omitted when not applicable).
+
+---
+
+## 1. Decisions & Assumptions (Aligned with User feedback)
+
+### D1 — Consultation validity window is 5 days
+For all categories except `IPD` and `EMERGENCY` (i.e. Outpatient, Antenatal, Immunization, Maternity, Dialysis), the consultation window is exactly 5 days (120 hours). EMR has a cron job (`endVisits.job.ts`) that automatically closes these visits after 5 days. Therefore, their validity limit is unconditionally `date_visit_start` + 5 days.
+
+### D2 — IPD & EMERGENCY Validity
+For `IPD` (Inpatient) and `EMERGENCY` visits (which are excluded from the 5-day auto-close cron):
+* If the visit has ended/closed, `consultation_valid_until` is set to `date_visit_ended` (discharge date).
+* If the visit is ongoing, `consultation_valid_until` is omitted from the event payload.
+
+
+---
+
+## 2. Task List
+
+### Phase 1 — Event Builder (`event-builder.ts`)
+- [x] 1.1 Widen `PrescribedLineInput` interface to include optional `visit_type?: string` and `consultation_valid_until?: string`.
+- [x] 1.2 Update `buildChargeCapturedEvent` to copy `visit_type` and `consultation_valid_until` to the payload body if present.
+- [x] 1.3 Add unit tests in `event-builder.test.ts` to assert that:
+  - Both fields are included when provided.
+  - Both fields are omitted from the payload (not sent as `null` or `undefined`) when not provided (retaining backward compatibility).
+
+### Phase 2 — Visit Resolution (`outbox-writer.ts`)
+- [x] 2.1 Implement `VisitResolver` class in `outbox-writer.ts` to cache lookups by `visit_id` over the transaction.
+- [x] 2.2 Map EMR `VisitCategory` values to the wire `visit_type` values (`Inpatient`, `Outpatient`, `Emergency`, `Antenatal`, `Immunization`, `Maternity`, `Dialysis`).
+- [x] 2.3 Calculate `consultation_valid_until` using `dayjs`:
+  - Non-IPD/EMERGENCY -> `date_visit_start` + 5 days.
+  - IPD/EMERGENCY -> `date_visit_ended` (if set).
+- [x] 2.4 Update `emitChargeCapturedForRows` to instantiate `VisitResolver` and pass resolved fields to `emitChargeCaptured`.
+
+### Phase 3 — Validation & Verification
+- [x] 3.1 Unit tests in `outbox-writer.test.ts` / `emit-for-rows.test.ts` asserting correct metadata emission for OPD and IPD rows.
+- [x] 3.2 Verify existing EMR test suite remains green.


### PR DESCRIPTION
## Summary
- Adds `buildChargeReversalRequestedEvent`, `emitChargeReversalRequested`, and `deletePrescribedLineWithReversalRequested` in the EMR outbox layer.
- Wires prescribe-line delete paths (drug, `additional_item`, test, service, investigation) to emit `charge.reversal.requested` before destroy.
- Extends contract-handshake and adds unit tests for builder/idempotency key semantics.

Companion to [ehmrs_accounting #211](https://github.com/Horlarmeday/ehmrs_accounting/pull/211) (Accounting issue #14).

**Note:** This branch also carries prior outbox work (visit metadata #192, void/close #163, demographics #43, etc.) ahead of `svsh_branch`.

## Test plan
- [x] `yarn jest src/modules/Outbox/charge-reversal-requested.test.ts src/modules/Outbox/contract-handshake.test.ts`